### PR TITLE
Use server and client lib in their own executables to avoid compiling same files twice

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -1,14 +1,8 @@
 add_executable (ug-client
     main.cpp
-    rendering/Animation.cpp
-    rendering/AnimatedSprite.cpp
-    rendering/AnimationController.cpp
-    systems/NetworkingClient.cpp
-    systems/ClientGameController.cpp
 )
 
 add_library(client-lib
-    main.cpp
     rendering/Animation.cpp
     rendering/AnimatedSprite.cpp
     rendering/AnimationController.cpp
@@ -16,4 +10,4 @@ add_library(client-lib
     systems/ClientGameController.cpp
 )
 
-target_link_libraries(ug-client PRIVATE common-lib)
+target_link_libraries(ug-client PRIVATE client-lib common-lib)

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1,13 +1,10 @@
 add_executable (ug-server
     main.cpp
-    systems/NetworkingServer.cpp
-    systems/ServerGameController.cpp
 )
 
 add_library(server-lib
-    main.cpp
     systems/NetworkingServer.cpp
     systems/ServerGameController.cpp
 )
 
-target_link_libraries(ug-server PRIVATE common-lib)
+target_link_libraries(ug-server PRIVATE server-lib common-lib)


### PR DESCRIPTION
Fixes #93 