### PR TITLE
Do not resolve collision if bodies are moving away from each other

### DIFF
--- a/src/common/physics/CollisionUtil.cpp
+++ b/src/common/physics/CollisionUtil.cpp
@@ -1,4 +1,7 @@
 #include "CollisionUtil.hpp"
+
+#include <cmath>
+
 #include "VectorUtil.hpp"
 
 /**
@@ -21,9 +24,18 @@ bool CollisionUtil::areIntersecting(const CircleRigidBody& circle_a,
  */
 Collision CollisionUtil::getCollision(const CircleRigidBody& circle_a,
                                       const CircleRigidBody& circle_b) {
+    bool collided = true;
     sf::Vector2f between = VectorUtil::getVector(circle_b.getCenter(), circle_a.getCenter());
     float overlap = circle_a.getRadius() + circle_b.getRadius() - VectorUtil::length(between);
     sf::Vector2f normal = VectorUtil::normalize(between);
+
+    sf::Vector2f relative_velocity = circle_a.getVelocity() - circle_b.getVelocity();
+    float velocity_along_normal = VectorUtil::dot(relative_velocity, normal);
+
+    // Do not consider collision if velocities are seperating
+    if (velocity_along_normal > 0) {
+        collided = false;
+    }
 
     std::pair<sf::Vector2f, sf::Vector2f> resolution;
     if (circle_a.isMovable() && circle_b.isMovable()) {
@@ -44,6 +56,7 @@ Collision CollisionUtil::getCollision(const CircleRigidBody& circle_a,
         .position = collision_point,
         .normal = normal,
         .resolution = resolution,
+        .collided = collided,
     };
 
     return collision;

--- a/src/common/physics/CollisionUtil.hpp
+++ b/src/common/physics/CollisionUtil.hpp
@@ -19,6 +19,7 @@ struct Collision {
     sf::Vector2f position;
     sf::Vector2f normal;
     std::pair<sf::Vector2f, sf::Vector2f> resolution;
+    bool collided;
 };
 
 namespace CollisionUtil {

--- a/src/common/physics/PhysicsController.cpp
+++ b/src/common/physics/PhysicsController.cpp
@@ -7,6 +7,7 @@
 
 #include "../events/CollisionEvent.hpp"
 #include "../events/EventController.hpp"
+#include "PhysicsDef.hpp"
 #include "VectorUtil.hpp"
 
 PhysicsController::PhysicsController() {}
@@ -48,6 +49,9 @@ void PhysicsController::resolveCollisions() {
 
             if (CollisionUtil::areIntersecting(circle_a, circle_b)) {
                 Collision collision = CollisionUtil::getCollision(circle_a, circle_b);
+                if (collision.collided == false) {
+                    continue;
+                }
                 resolveCollision(circle_a, circle_b, collision);
                 fireCollisionEvent(collision);
             }
@@ -63,6 +67,10 @@ void PhysicsController::resolveCollision(CircleRigidBody& circle_a, CircleRigidB
 
     // Apply impulses resulting from collision
     auto impulses = CollisionUtil::getImpulses(circle_a, circle_b, collision);
+
+    impulses.first.magnitude *= PhysicsDef::IMPULSE_MILTIPLIER;
+    impulses.second.magnitude *= PhysicsDef::IMPULSE_MILTIPLIER;
+
     circle_a.applyImpulse(impulses.first);
     circle_b.applyImpulse(impulses.second);
 }

--- a/src/common/physics/PhysicsDef.hpp
+++ b/src/common/physics/PhysicsDef.hpp
@@ -8,6 +8,7 @@ namespace PhysicsDef {
         float magnitude;
         sf::Vector2f normal;
     };
+    const float IMPULSE_MILTIPLIER = 3.f;
 }; // namespace PhysicsDef
 
 #endif /* PhysicsDef_hpp */

--- a/src/common/physics/VectorUtil.cpp
+++ b/src/common/physics/VectorUtil.cpp
@@ -16,7 +16,7 @@ sf::Vector2f VectorUtil::normalize(const sf::Vector2f& source) {
 }
 
 float VectorUtil::distance(const sf::Vector2f& point_a, const sf::Vector2f& point_b) {
-    return sqrt(pow((point_b.x - point_a.x), 2) + pow((point_b.y - point_a.y), 2));
+    return sqrt(pow((point_b.x - point_a.x), 2.f) + pow((point_b.y - point_a.y), 2.f));
 }
 
 sf::Vector2f VectorUtil::getVector(const sf::Vector2f& point_a, const sf::Vector2f& point_b) {


### PR DESCRIPTION
I've also added an impulse multiplier. Groups/Mines now 'bounce' off each other when colliding.