### PR TITLE
Client input improvements

### DIFF
--- a/src/client/systems/ClientGameController.cpp
+++ b/src/client/systems/ClientGameController.cpp
@@ -11,7 +11,6 @@ ClientGameController::ClientGameController(size_t max_player_count, size_t max_m
                                            ClientInputKeys keys)
     : GameController(max_player_count, max_mine_count), m_networkingClient(new NetworkingClient()),
       m_animationController(new AnimationController()), m_clientInputKeys(keys) {
-    m_clientUnreliableUpdate.setAll(false);
     addEventListeners();
 }
 

--- a/src/client/systems/NetworkingClient.hpp
+++ b/src/client/systems/NetworkingClient.hpp
@@ -27,8 +27,8 @@ class NetworkingClient {
     std::pair<bool, uint32_t> getPlayerId() const;
     int getClientId() const;
     bool getGameStateIsFresh() const;
-    void setClientUnreliableUpdate(ClientUnreliableUpdate client_unreliable_update);
-    void setClientReliableUpdate(ClientReliableUpdate client_reliable_update);
+    void pushClientUnreliableUpdate(ClientUnreliableUpdate client_unreliable_update);
+    void pushClientReliableUpdate(ClientReliableUpdate client_reliable_update);
 
   private:
     // Sockets
@@ -72,8 +72,8 @@ class NetworkingClient {
     std::mutex m_gameState_lock;
     GameState m_gameState_t;
 
-    std::mutex m_clientUnreliableUpdate_lock;
-    ClientUnreliableUpdate m_clientUnreliableUpdate_t;
+    std::mutex m_clientUnreliableUpdates_lock;
+    std::queue<ClientUnreliableUpdate> m_clientUnreliableUpdates_t;
 
     std::mutex m_clientReliableUpdates_lock;
     std::queue<ClientReliableUpdate> m_clientReliableUpdates_t;

--- a/src/common/objects/Player.cpp
+++ b/src/common/objects/Player.cpp
@@ -4,7 +4,7 @@
 
 #include "../util/network_util.hpp"
 
-Player::Player(uint32_t id) : GameObject(id), m_direction(1.0, 1.0), m_joinable(false) {}
+Player::Player(uint32_t id) : GameObject(id), m_direction(0.0, 0.0), m_joinable(false) {}
 
 Player::~Player() {}
 

--- a/src/common/systems/GameController.cpp
+++ b/src/common/systems/GameController.cpp
@@ -64,6 +64,10 @@ void GameController::updateGameObjects(std::shared_ptr<PlayerInputs> pi) {
     m_playerController->update(pi);
     m_groupController->update();
     m_mineController->update();
+
+    // Clear uptades since they've already been "consumed"
+    pi->player_reliable_updates.clear();
+    pi->player_unreliable_updates.clear();
 }
 
 void GameController::updateGameObjectsPostPhysics() {

--- a/src/common/util/StateDef.cpp
+++ b/src/common/util/StateDef.cpp
@@ -78,11 +78,13 @@ GameState unpack_game_state(sf::Packet game_state_packet) {
 }
 
 sf::Packet& operator<<(sf::Packet& packet, const ClientUnreliableUpdate& cuu) {
-    return packet << cuu.direction;
+    return packet << cuu.toggle_up << cuu.toggle_down << cuu.toggle_right << cuu.toggle_left
+                  << cuu.toggle_stop;
 }
 
 sf::Packet& operator>>(sf::Packet& packet, ClientUnreliableUpdate& cuu) {
-    return packet >> cuu.direction;
+    return packet >> cuu.toggle_up >> cuu.toggle_down >> cuu.toggle_right >> cuu.toggle_left >>
+           cuu.toggle_stop;
 }
 
 sf::Packet& operator<<(sf::Packet& packet, const ClientReliableUpdate& cru) {

--- a/src/common/util/StateDef.hpp
+++ b/src/common/util/StateDef.hpp
@@ -22,7 +22,21 @@ sf::Packet pack_game_state(GameState game_state);
 GameState unpack_game_state(sf::Packet game_state_packet);
 
 struct ClientUnreliableUpdate {
-    sf::Vector2f direction = sf::Vector2f(0.f, 0.f);
+    bool toggle_up;
+    bool toggle_down;
+    bool toggle_right;
+    bool toggle_left;
+    bool toggle_stop;
+    void setAll(bool value) {
+        toggle_up = value;
+        toggle_down = value;
+        toggle_right = value;
+        toggle_left = value;
+        toggle_stop = value;
+    };
+    bool allFalse() {
+        return !toggle_up && !toggle_down && !toggle_right && !toggle_left && !toggle_stop;
+    };
 };
 
 struct ClientReliableUpdate {

--- a/src/common/util/Util.hpp
+++ b/src/common/util/Util.hpp
@@ -1,0 +1,31 @@
+#ifndef Util_hpp
+#define Util_hpp
+
+#include "../physics/VectorUtil.hpp"
+#include <SFML/Graphics.hpp>
+
+namespace Util {
+    sf::Vector2f inputToDirection(bool toggle_up, bool toggle_down, bool toggle_right,
+                                  bool toggle_left, bool toggle_stop) {
+        if (toggle_stop) {
+            return sf::Vector2f(0.f, 0.f);
+        }
+
+        sf::Vector2f direction = sf::Vector2f(0.f, 0.f);
+        if (toggle_up) {
+            direction += sf::Vector2f(0.f, -1.f);
+        }
+        if (toggle_down) {
+            direction += sf::Vector2f(0.f, 1.f);
+        }
+        if (toggle_left) {
+            direction += sf::Vector2f(-1.f, 0.f);
+        }
+        if (toggle_right) {
+            direction += sf::Vector2f(1.f, 0.f);
+        }
+        return VectorUtil::normalize(direction);
+    };
+} // namespace Util
+
+#endif /* VectorUtil_hpp */


### PR DESCRIPTION
Fixes  #103

[fd5b091] Client input improvements

- Send toggle of toggle unreliable inputs instead of sending a computed
value e.g. up=true instead of direction=(0,-1)
- Only send client inputs to server when present
- Only apply client inputs once in an update. This was a bug before
where we would apply it "step" amount of times. A single update can have
many steps.