### PR TITLE
Connecting state

### DIFF
--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -37,23 +37,10 @@ int main(int, char const**) {
         .ungroup = sf::Keyboard::Escape,
         .stop = sf::Keyboard::Space,
     };
-    ClientGameController client_game_controller(input_keys, window);
+    ClientGameController client_game_controller(input_keys, window, buffer, buffer_scaling_factor,
+                                                buffer_sprite);
 
-    // Start the game loop
-    while (window.isOpen()) {
-        // Update
-        client_game_controller.step();
-
-        // Display
-        window.clear(sf::Color::White);
-        buffer.clear(sf::Color(12, 30, 39));
-
-        client_game_controller.updateView(window, buffer_scaling_factor);
-        client_game_controller.draw(buffer);
-        buffer.display();
-        window.draw(buffer_sprite);
-        window.display();
-    }
+    client_game_controller.start();
 
     return EXIT_SUCCESS;
 }

--- a/src/client/systems/ClientGameController.cpp
+++ b/src/client/systems/ClientGameController.cpp
@@ -23,11 +23,16 @@ ClientGameController::~ClientGameController() {
 }
 
 void ClientGameController::start() {
+    registerClient();
     while (m_window.isOpen()) {
         step();
-        updateView();
         draw();
     }
+}
+
+void ClientGameController::registerClient() {
+    std::cout << "Registering client with server..." << std::endl;
+    m_playerId = m_networkingClient->registerClientAndFetchPlayerId();
 }
 
 void ClientGameController::addEventListeners() {
@@ -51,6 +56,8 @@ void ClientGameController::updateView() {
 }
 
 void ClientGameController::draw() {
+    updateView();
+
     m_window.clear(sf::Color::White);
     m_buffer.clear(BACKGROUND_COLOR);
 
@@ -63,17 +70,10 @@ void ClientGameController::draw() {
 }
 
 InputDef::PlayerInputs ClientGameController::getPlayerInputs() {
-    if (!m_playerIdAvailable) {
-        return InputDef::PlayerInputs();
-    }
-
     return m_inputController->getPlayerInputs(m_playerId);
 }
 
 void ClientGameController::preUpdate() {
-    fetchPlayerId(); // TODO(sourenp|#108): Move this to a "connecting" state that runs before
-                     // updates begin.
-
     auto inputs = m_inputController->collectInputs(m_window);
     sendInputs(inputs);
     saveInputs(inputs);
@@ -125,12 +125,6 @@ void ClientGameController::rewindAndReplay() {
         }
     }
     m_tickToInput.clear();
-}
-
-void ClientGameController::fetchPlayerId() {
-    if (!m_playerIdAvailable) {
-        std::tie(m_playerIdAvailable, m_playerId) = m_networkingClient->getPlayerId();
-    }
 }
 
 /**

--- a/src/client/systems/ClientGameController.hpp
+++ b/src/client/systems/ClientGameController.hpp
@@ -18,11 +18,12 @@
 class ClientGameController : public GameController {
 
   public:
-    explicit ClientGameController(InputDef::InputKeys keys, sf::RenderWindow& window);
+    explicit ClientGameController(InputDef::InputKeys keys, sf::RenderWindow& window,
+                                  sf::RenderTexture& buffer, sf::Vector2f buffer_scaling_factor,
+                                  sf::Sprite& buffer_sprite);
     ~ClientGameController();
 
-    void updateView(sf::RenderWindow& window, sf::Vector2f buffer_scaling_factor);
-    void draw(sf::RenderTexture& buffer);
+    void start();
 
   private:
     // Overrides
@@ -35,6 +36,8 @@ class ClientGameController : public GameController {
     void setTick(unsigned int tick) override;
 
     // Methods
+    void updateView();
+    void draw();
     void addEventListeners();
     void fetchPlayerId();
     void rewindAndReplay();
@@ -56,6 +59,9 @@ class ClientGameController : public GameController {
     std::unique_ptr<InputController> m_inputController;
 
     sf::RenderWindow& m_window;
+    sf::RenderTexture& m_buffer;
+    sf::Vector2f m_bufferScalingFactor;
+    sf::Sprite& m_bufferSprite;
 };
 
 #endif /* ClientGameController_hpp */

--- a/src/client/systems/ClientGameController.hpp
+++ b/src/client/systems/ClientGameController.hpp
@@ -36,6 +36,7 @@ class ClientGameController : public GameController {
     void setTick(unsigned int tick) override;
 
     // Methods
+    void registerClient();
     void updateView();
     void draw();
     void addEventListeners();
@@ -47,8 +48,6 @@ class ClientGameController : public GameController {
     void saveInputs(std::pair<InputDef::ReliableInput, InputDef::UnreliableInput> inputs);
 
     // Variables
-
-    bool m_playerIdAvailable;
     uint32_t m_playerId;
 
     std::unordered_map<unsigned int, InputDef::ClientInputAndTick>

--- a/src/client/systems/NetworkingClient.hpp
+++ b/src/client/systems/NetworkingClient.hpp
@@ -21,11 +21,11 @@ class NetworkingClient {
     NetworkingClient();
     ~NetworkingClient();
 
+    uint32_t registerClientAndFetchPlayerId();
     GameState getGameState();
     void incrementTick();
     uint getTick() const;
     void setTick(uint tick);
-    std::pair<bool, uint32_t> getPlayerId() const;
     int getClientId() const;
     bool getGameStateIsFresh() const;
     void pushUnreliableInput(InputDef::UnreliableInput unreliable_input);
@@ -58,16 +58,13 @@ class NetworkingClient {
     // Methods
     void sendUnreliableInput();
     void sendReliableInput();
-    void sendPlayerIdRequest();
-    bool readRegistrationResponse();
-    bool registerNetworkingClient();
+    void readRegistrationResponse();
+    void registerClient();
     void addEventListeners();
     void handlePlayerCreatedEvent(std::shared_ptr<Event> event);
+    uint32_t fetchPlayerId();
 
     // Misc
-    std::atomic<bool> m_playerIdAvialable_ta{false};
-    std::atomic<uint32_t> m_playerId_ta{0};
-
     std::atomic<int> m_clientId_ta{-1};
     std::atomic<uint> m_tick_ta{0};
     std::atomic<bool> m_gameStateIsFresh_ta{true};

--- a/src/common/util/game_settings.hpp
+++ b/src/common/util/game_settings.hpp
@@ -8,6 +8,7 @@
 const sf::Vector2f GAME_SIZE(2688 * 4, 1512 * 4);
 const sf::Vector2f WINDOW_RESOLUTION(2688, 1512);
 const float GAME_SCALE = 2.f;
+const sf::Color BACKGROUND_COLOR(12, 30, 39);
 
 const bool USE_SHADER = true;
 

--- a/src/common/util/game_settings.hpp
+++ b/src/common/util/game_settings.hpp
@@ -24,6 +24,8 @@ const float GROUP_SPEED = 100.f;
 
 /* Threads */
 
+const std::chrono::milliseconds CLIENT_FETCH_PLAYER_ID_SLEEP(16);
+
 const std::chrono::milliseconds SERVER_INPUT_WINDOW_SLEEP(50);
 
 const std::chrono::milliseconds CLIENT_RELIABLE_SEND_SLEEP(16);

--- a/src/server/systems/NetworkingServer.cpp
+++ b/src/server/systems/NetworkingServer.cpp
@@ -252,6 +252,9 @@ void NetworkingServer::clientDisconnect(sf::TcpSocket& client, sf::Uint32 client
         new ClientDisconnectedEvent(client_id, player_id)));
 }
 
+/**
+ * Send player id if it's available.
+ */
 void NetworkingServer::sendPlayerId(sf::TcpSocket& socket, sf::Uint32 client_id) {
     sf::Uint32 player_id;
     {
@@ -286,7 +289,7 @@ void NetworkingServer::setClientReliableUpdate(sf::Packet packet, int client_id)
     }
 }
 
-void NetworkingServer::registerClient(sf::Packet packet, sf::TcpSocket& client,
+void NetworkingServer::registerClient(sf::Packet packet, sf::TcpSocket& socket,
                                       sf::Uint32 client_id) {
     // Save client udp port
     sf::Uint16 client_udp_port;
@@ -306,7 +309,7 @@ void NetworkingServer::registerClient(sf::Packet packet, sf::TcpSocket& client,
     sf::Uint32 register_cmd = (sf::Uint32)ReliableCommandType::register_client;
     ReliableCommand reliable_command = {client_id, register_cmd, (sf::Uint32)m_tick_ta};
     if (response_packet << reliable_command << server_udp_port) {
-        client.send(response_packet);
+        socket.send(response_packet);
         EventController::getInstance().queueEvent(
             std::shared_ptr<ClientConnectedEvent>(new ClientConnectedEvent(client_id)));
         std::cout << "Received client registration. Issued client ID " << client_id << std::endl;

--- a/src/server/systems/NetworkingServer.hpp
+++ b/src/server/systems/NetworkingServer.hpp
@@ -55,7 +55,7 @@ class NetworkingServer {
 
     // Methods
     void clientDisconnect(sf::TcpSocket& client, sf::Uint32 client_id);
-    void registerClient(sf::Packet packet, sf::TcpSocket& client, sf::Uint32 client_id);
+    void registerClient(sf::Packet packet, sf::TcpSocket& socket, sf::Uint32 client_id);
     void sendPlayerId(sf::TcpSocket& socket, sf::Uint32 client_id);
     void handleReliableCommand(sf::Socket::Status status, sf::Packet command_packet,
                                sf::SocketSelector& selector, sf::TcpSocket& socket,

--- a/tests/client/systems/tests-ClientGameController.cpp
+++ b/tests/client/systems/tests-ClientGameController.cpp
@@ -11,7 +11,13 @@ SCENARIO("ClientGameController runs successfully",
         InputDef::InputKeys keys = {sf::Keyboard::Up,   sf::Keyboard::Down, sf::Keyboard::Right,
                                     sf::Keyboard::Left, sf::Keyboard::G,    sf::Keyboard::Escape,
                                     sf::Keyboard::Space};
-        ClientGameController client_game_controller(keys, window);
+
+        sf::RenderTexture buffer;
+        buffer.create(1, 1);
+        sf::Vector2f buffer_scaling_factor(1.f, 1.f);
+        sf::Sprite buffer_sprite(buffer.getTexture());
+        ClientGameController client_game_controller(keys, window, buffer, buffer_scaling_factor,
+                                                    buffer_sprite);
 
         WHEN("is stepped") {
             client_game_controller.step();


### PR DESCRIPTION
Fixes #108 

[8fbd79a] Move game loop from main to ClientGameController

- main now just calls client_game_controller.start()

[201959d] Get player id from server during registration

- Now when the game loop starts will be guaranteed to have the player id
- We get the player id by continously sending tcp commands to the server
until we get a response. We need to do this because the server doesn't
immedietely have the player id when the client registers. The server
can't send the player id over the tcp socket once it's available because
it doesn't have a socket (the socket is only available when the client
sends a tcp request).

