### PR TITLE
Mining mechanism

### DIFF
--- a/src/common/objects/CircleGameObject.hpp
+++ b/src/common/objects/CircleGameObject.hpp
@@ -56,6 +56,9 @@ class CircleGameObject : public GameObject {
     void setOutlineColor(sf::Color color) {
         m_outlineShape.setOutlineColor(color);
     };
+    void setColor(sf::Color color) {
+        m_circleShape.setFillColor(color);
+    }
 
     void draw(sf::RenderTarget& render_target);
 

--- a/src/common/objects/Mine.cpp
+++ b/src/common/objects/Mine.cpp
@@ -18,14 +18,25 @@ sf::Packet& operator>>(sf::Packet& packet, MineUpdate& mine_update) {
            mine_update.y_pos >> mine_update.radius >> mine_update.shader_key;
 }
 
-Mine::Mine(uint32_t id, sf::Vector2f position, float size, sf::Color color, PhysicsController& pc,
-           ResourceStore& rs) :
+Mine::Mine(uint32_t id, sf::Vector2f position, float size, sf::Color color,
+           ResourceType resource_type, PhysicsController& pc, ResourceStore& rs) :
     CircleGameObject(id, position, size, color, pc, rs, std::numeric_limits<float>::infinity(),
-                     false) {
+                     false),
+    m_resourceType(resource_type) {
     setTexture(RenderingDef::TextureKey::mine_pattern);
 }
 
 Mine::~Mine() {
+}
+
+void Mine::draw(sf::RenderTarget& render_target) {
+    if (m_resourceCount == 0) {
+        setColor(sf::Color::White);
+    } else {
+        setColor(RenderingDef::MINE_COLORS[m_resourceType]);
+    }
+
+    CircleGameObject::draw(render_target);
 }
 
 MineUpdate Mine::getUpdate() {

--- a/src/common/objects/Mine.cpp
+++ b/src/common/objects/Mine.cpp
@@ -31,7 +31,7 @@ Mine::~Mine() {
 
 void Mine::draw(sf::RenderTarget& render_target) {
     if (m_resourceCount == 0) {
-        setColor(sf::Color::White);
+        setColor(RenderingDef::EMPTY_MINE_COLOR);
     } else {
         setColor(RenderingDef::MINE_COLORS[m_resourceType]);
     }

--- a/src/common/objects/Mine.hpp
+++ b/src/common/objects/Mine.hpp
@@ -9,6 +9,7 @@
 #include <SFML/Network.hpp>
 
 #include "../resources/ResourceStore.hpp"
+#include "../systems/ResourceController.hpp"
 #include "CircleGameObject.hpp"
 
 struct MineUpdate {
@@ -25,14 +26,28 @@ sf::Packet& operator>>(sf::Packet& packet, MineUpdate& mine_update);
 
 class Mine : public CircleGameObject {
   public:
-    Mine(uint32_t id, sf::Vector2f position, float size, sf::Color color, PhysicsController& pc,
-         ResourceStore& rs);
+    Mine(uint32_t id, sf::Vector2f position, float size, sf::Color color,
+         ResourceType resource_type, PhysicsController& pc, ResourceStore& rs);
     ~Mine();
     Mine(const Mine& temp_obj) = delete;            // TODO: define this
     Mine& operator=(const Mine& temp_obj) = delete; // TODO: define this
 
+    void setResourceCount(uint32_t count) {
+        m_resourceCount = count;
+    }
+
+    ResourceType getResourceType() const {
+        return m_resourceType;
+    }
+
     MineUpdate getUpdate();
     void applyUpdate(MineUpdate mu);
+
+    void draw(sf::RenderTarget& render_target);
+
+  private:
+    ResourceType m_resourceType;
+    uint32_t m_resourceCount = 0;
 };
 
 #endif /* Mine_hpp */

--- a/src/common/rendering/RenderingDef.hpp
+++ b/src/common/rendering/RenderingDef.hpp
@@ -21,10 +21,12 @@ namespace RenderingDef {
     const sf::Color DARK_COLOR(63, 157, 130);
     const sf::Color LIGHT_COLOR(161, 205, 115);
     const sf::Color LIGHTEST_COLOR(236, 219, 96);
-
     const std::array<sf::Color, RESOURCE_TYPE_COUNT> MINE_COLORS = {
         RenderingDef::DARKEST_COLOR, RenderingDef::DARK_COLOR, RenderingDef::LIGHT_COLOR,
         RenderingDef::LIGHTEST_COLOR};
+    const sf::Color EMPTY_MINE_COLOR = sf::Color::White;
+    const sf::Color DEFAULT_GROUP_COLOR = sf::Color::Transparent;
+    const sf::Color DEFAULT_MINE_COLOR = sf::Color::White;
 }; // namespace RenderingDef
 
 #endif /* RenderingDef_hpp */

--- a/src/common/rendering/RenderingDef.hpp
+++ b/src/common/rendering/RenderingDef.hpp
@@ -4,6 +4,8 @@
 #include <SFML/Graphics.hpp>
 #include <memory>
 
+#include "../systems/ResourceController.hpp"
+
 namespace RenderingDef {
     const bool USE_SHADERS = true;
     const std::size_t CIRCLE_POINT_COUNT = 60;
@@ -19,6 +21,10 @@ namespace RenderingDef {
     const sf::Color DARK_COLOR(63, 157, 130);
     const sf::Color LIGHT_COLOR(161, 205, 115);
     const sf::Color LIGHTEST_COLOR(236, 219, 96);
+
+    const std::array<sf::Color, RESOURCE_TYPE_COUNT> MINE_COLORS = {
+        RenderingDef::DARKEST_COLOR, RenderingDef::DARK_COLOR, RenderingDef::LIGHT_COLOR,
+        RenderingDef::LIGHTEST_COLOR};
 }; // namespace RenderingDef
 
 #endif /* RenderingDef_hpp */

--- a/src/common/systems/GameController.cpp
+++ b/src/common/systems/GameController.cpp
@@ -47,9 +47,9 @@ void GameController::step() {
 }
 
 void GameController::computeGameState(const InputDef::PlayerInputs& pi, sf::Int32 delta_ms) {
-    EventController::getInstance().forceProcessEvents();
     m_gameObjectController->update(pi);
     m_physicsController->update(delta_ms);
     m_gameObjectController->updatePostPhysics();
+    EventController::getInstance().forceProcessEvents();
     incrementTick();
 }

--- a/src/common/systems/GameObjectController.hpp
+++ b/src/common/systems/GameObjectController.hpp
@@ -28,12 +28,14 @@ class GameObjectController {
   private:
     void addEventListeners();
     void handleClientConnectedEvent(std::shared_ptr<Event> event);
+    void handleCollisionEvent(std::shared_ptr<Event> event);
+    void transferResources(uint32_t circle_a_id, uint32_t circle_b_id);
 
+    ResourceController m_resourceController;
     GameObjectStore m_gameObjectStore;
     GroupController m_groupController;
     PlayerController m_playerController;
     MineController m_mineController;
-    ResourceController m_resourceController;
 };
 
 #endif /* GameObjectController_hpp */

--- a/src/common/systems/GameObjectStore.cpp
+++ b/src/common/systems/GameObjectStore.cpp
@@ -28,13 +28,12 @@ GameObjectStore::GameObjectStore(PhysicsController& pc, ResourceStore& rs) :
     }
 
     // Initialize Mines
-    std::vector<sf::Color> mine_colors = {RenderingDef::DARKEST_COLOR, RenderingDef::DARK_COLOR,
-                                          RenderingDef::LIGHT_COLOR, RenderingDef::LIGHTEST_COLOR};
     for (int i = 0; i < MAX_MINE_COUNT; i++) {
         uint32_t new_mine_id = IdFactory::getInstance().getNextId(GameObjectType::mine);
         m_mines.push_back(std::shared_ptr<Mine>(new Mine(
             new_mine_id, sf::Vector2f(MINE_START_OFFSET_X, MINE_START_OFFSET_Y * (i + 1) - 100.f),
-            MINE_SIZE, mine_colors[i % mine_colors.size()], m_physicsController, m_resourceStore)));
+            MINE_SIZE, sf::Color::White, ResourceType(i % RESOURCE_TYPE_COUNT), m_physicsController,
+            m_resourceStore)));
     }
 }
 

--- a/src/common/systems/GameObjectStore.cpp
+++ b/src/common/systems/GameObjectStore.cpp
@@ -24,7 +24,7 @@ GameObjectStore::GameObjectStore(PhysicsController& pc, ResourceStore& rs) :
         uint32_t new_group_id = IdFactory::getInstance().getNextId(GameObjectType::group);
         m_groups.push_back(std::shared_ptr<Group>(new Group(
             new_group_id, sf::Vector2f(GROUP_START_OFFSET_X * (i + 1), GROUP_START_OFFSET_Y),
-            sf::Color::Transparent, m_physicsController, m_resourceStore)));
+            RenderingDef::DEFAULT_GROUP_COLOR, m_physicsController, m_resourceStore)));
     }
 
     // Initialize Mines
@@ -32,8 +32,8 @@ GameObjectStore::GameObjectStore(PhysicsController& pc, ResourceStore& rs) :
         uint32_t new_mine_id = IdFactory::getInstance().getNextId(GameObjectType::mine);
         m_mines.push_back(std::shared_ptr<Mine>(new Mine(
             new_mine_id, sf::Vector2f(MINE_START_OFFSET_X, MINE_START_OFFSET_Y * (i + 1) - 100.f),
-            MINE_SIZE, sf::Color::White, ResourceType(i % RESOURCE_TYPE_COUNT), m_physicsController,
-            m_resourceStore)));
+            MINE_SIZE, RenderingDef::DEFAULT_MINE_COLOR, ResourceType(i % RESOURCE_TYPE_COUNT),
+            m_physicsController, m_resourceStore)));
     }
 }
 

--- a/src/common/systems/GroupController.cpp
+++ b/src/common/systems/GroupController.cpp
@@ -265,6 +265,10 @@ void GroupController::removePlayer(uint32_t player_id) {
     m_playerToGroup.erase(player_id);
 }
 
+std::vector<uint32_t> GroupController::getGroupPlayerIds(uint32_t group_id) {
+    return m_groupToPlayers[group_id];
+}
+
 /* Network utilities */
 
 GroupControllerUpdate GroupController::getUpdate() {

--- a/src/common/systems/GroupController.hpp
+++ b/src/common/systems/GroupController.hpp
@@ -47,9 +47,10 @@ class GroupController {
     GroupControllerUpdate getUpdate();
     void applyUpdate(GroupControllerUpdate gcu);
     uint32_t getGroupId(uint32_t player_id);
+    Group& getGroup(uint32_t group_id);
+    std::vector<uint32_t> getGroupPlayerIds(uint32_t group_id);
 
   private:
-    Group& getGroup(uint32_t group_id);
     std::vector<uint32_t> getEmptyGroupIds();
     std::pair<TypeDef::ids, TypeDef::ids> partitionGroupsByPlayerCount();
     Player& getPlayer(uint32_t player_id);

--- a/src/common/systems/MineController.cpp
+++ b/src/common/systems/MineController.cpp
@@ -25,7 +25,7 @@ uint32_t MineController::createMine() {
     Mine& new_mine = *m_mines[next_mine_index];
     uint32_t new_mine_id = new_mine.getId();
     new_mine.setActive(true);
-    m_resourceController.add(new_mine_id, new_mine.getResourceType(), 4);
+    m_resourceController.add(new_mine_id, new_mine.getResourceType(), MINE_RESOURCE_COUNT);
     return new_mine_id;
 }
 

--- a/src/common/systems/MineController.cpp
+++ b/src/common/systems/MineController.cpp
@@ -6,7 +6,8 @@
 #include "../rendering/RenderingDef.hpp"
 #include "../util/game_settings.hpp"
 
-MineController::MineController(std::vector<std::shared_ptr<Mine>>& mines) : m_mines(mines) {
+MineController::MineController(std::vector<std::shared_ptr<Mine>>& mines, ResourceController& rc) :
+    m_mines(mines), m_resourceController(rc) {
     for (int i = 0; i < MAX_MINE_COUNT; i++) {
         createMine();
     }
@@ -24,6 +25,7 @@ uint32_t MineController::createMine() {
     Mine& new_mine = *m_mines[next_mine_index];
     uint32_t new_mine_id = new_mine.getId();
     new_mine.setActive(true);
+    m_resourceController.add(new_mine_id, new_mine.getResourceType(), 4);
     return new_mine_id;
 }
 
@@ -34,7 +36,9 @@ void MineController::draw(sf::RenderTarget& target) {
 }
 
 void MineController::update() {
-    // noop
+    for (auto& mine : m_mines) {
+        mine->setResourceCount(m_resourceController.get(mine->getId(), mine->getResourceType()));
+    }
 }
 
 void MineController::updatePostPhysics() {
@@ -43,6 +47,6 @@ void MineController::updatePostPhysics() {
     }
 }
 
-std::shared_ptr<Mine>& MineController::getMine(uint32_t mine_id) {
-    return m_mines[IdFactory::getInstance().getIndex(mine_id)];
+Mine& MineController::getMine(uint32_t mine_id) {
+    return *m_mines[IdFactory::getInstance().getIndex(mine_id)];
 }

--- a/src/common/systems/MineController.hpp
+++ b/src/common/systems/MineController.hpp
@@ -5,10 +5,11 @@
 
 #include "../objects/Mine.hpp"
 #include "../resources/ResourceStore.hpp"
+#include "ResourceController.hpp"
 
 class MineController {
   public:
-    MineController(std::vector<std::shared_ptr<Mine>>& mines);
+    MineController(std::vector<std::shared_ptr<Mine>>& mines, ResourceController& rc);
     ~MineController();
     MineController(const MineController& temp_obj) = delete;
     MineController& operator=(const MineController& temp_obj) = delete;
@@ -17,11 +18,12 @@ class MineController {
     void draw(sf::RenderTarget& target);
     void update();
     void updatePostPhysics();
-    std::shared_ptr<Mine>& getMine(uint32_t mine_id);
+    Mine& getMine(uint32_t mine_id);
 
   private:
     std::vector<std::shared_ptr<Mine>> m_mines;
     size_t nextMineIndex = 0;
+    ResourceController& m_resourceController;
 };
 
 #endif /* MineController_hpp */

--- a/src/common/systems/ResourceController.cpp
+++ b/src/common/systems/ResourceController.cpp
@@ -5,7 +5,7 @@
 
 void ResourceController::init(uint32_t id) {
     if (m_resourceCounts.count(id) == 0) {
-        m_resourceCounts[id] = {0, 0, 0, 0};
+        m_resourceCounts[id] = {};
     }
 }
 

--- a/src/common/systems/ResourceController.hpp
+++ b/src/common/systems/ResourceController.hpp
@@ -12,7 +12,7 @@
 
 enum ResourceType { RED, GREEN, BLUE, YELLOW };
 const size_t RESOURCE_TYPE_COUNT = 4;
-const std::array<std::string, RESOURCE_TYPE_COUNT> RESOURCE_NAME = {"R", "G", "B", "Y"};
+const std::array<std::string, RESOURCE_TYPE_COUNT> RESOURCE_NAME = {"A", "B", "C", "D"};
 
 /* Network utilities */
 

--- a/src/common/util/game_def.hpp
+++ b/src/common/util/game_def.hpp
@@ -18,6 +18,10 @@ struct ReliableCommand {
 enum ReliableCommandType { register_client, player_id, reliable_input };
 enum UnreliableCommandType { unreliable_input, fetch_state };
 
-enum GameObjectType { group, mine, player };
+enum GameObjectType {
+    player,
+    group,
+    mine,
+};
 
 #endif /* game_def_hpp */

--- a/src/common/util/game_settings.hpp
+++ b/src/common/util/game_settings.hpp
@@ -22,6 +22,7 @@ const float MINE_START_OFFSET_Y = 200.f;
 const float GROUP_MEMBER_SIZE = 10.f;
 const float MINE_SIZE = 80.f;
 const float GROUP_SPEED = 100.f;
+const uint32_t MINE_RESOURCE_COUNT = 4;
 
 /* Threads */
 


### PR DESCRIPTION
**Description**

*Group mines full capacity of mine.*
*Notice player's resource count rising on top right and how mine turns white when empty*
![mining_mechanism](https://user-images.githubusercontent.com/3184499/69961503-7179c380-1525-11ea-882a-6f68e7ff6dfe.gif)

**Fixes**

Fixes #14 

**Commits**

[8c7b1de] Mining mechanism
- Mines now have a resource type and count. Their color is set according to their resource type and they will turn white when their count reaches 0. They start with a count of 4 for now.
- On collision, if the circles are a group and a mine, for each player in the group a single resource will be moved from the mine to the player.

