### PR TITLE
Create constants for graphics

### DIFF
--- a/src/client/rendering/AnimatedSprite.cpp
+++ b/src/client/rendering/AnimatedSprite.cpp
@@ -13,7 +13,7 @@
  */
 AnimatedSprite::AnimatedSprite(sf::Texture& spritesheet_texture, sf::Vector2u spritesheet_size,
                                sf::Int32 duration_ms, sf::Vector2f position,
-                               sf::Vector2f scale_factor) :
+                               sf::Vector2f scale_factor, sf::Color color) :
     m_sprite(spritesheet_texture),
     m_animation(m_sprite) {
     sf::Int32 frame_count = spritesheet_size.x * spritesheet_size.y;
@@ -27,7 +27,7 @@ AnimatedSprite::AnimatedSprite(sf::Texture& spritesheet_texture, sf::Vector2u sp
             m_animation.addFrame({sf::IntRect(position, size), duration_ms / frame_count});
         }
     }
-
+    m_sprite.setColor(color);
     m_sprite.scale(scale_factor);
     m_sprite.setOrigin({frame_width / 2.f, frame_height / 2.f});
     m_sprite.setPosition(position);

--- a/src/client/rendering/AnimatedSprite.hpp
+++ b/src/client/rendering/AnimatedSprite.hpp
@@ -12,7 +12,8 @@
 class AnimatedSprite {
   public:
     AnimatedSprite(sf::Texture& spritesheet_texture, sf::Vector2u spritesheet_size,
-                   sf::Int32 duration_ms, sf::Vector2f position, sf::Vector2f scale_factor);
+                   sf::Int32 duration_ms, sf::Vector2f position, sf::Vector2f scale_factor,
+                   sf::Color color);
     ~AnimatedSprite(){};
 
     void draw(sf::RenderTarget& target);

--- a/src/client/rendering/AnimationController.cpp
+++ b/src/client/rendering/AnimationController.cpp
@@ -47,8 +47,8 @@ void AnimationController::handleCollisionEvent(std::shared_ptr<Event> event) {
 }
 
 void AnimationController::createCollisionAnimation(const sf::Vector2f& collision_position) {
-    auto collision_sprite = std::unique_ptr<AnimatedSprite>(
-        new AnimatedSprite(*m_resourceStore.getTexture(RenderingDef::TextureKey::collision), {6, 1},
-                           240, collision_position, {2.f, 2.f}));
+    auto collision_sprite = std::unique_ptr<AnimatedSprite>(new AnimatedSprite(
+        *m_resourceStore.getTexture(RenderingDef::TextureKey::collision), {6, 1}, 240,
+        collision_position, {2.f, 2.f}, RenderingDef::COLLISION_ANIMATION_COLOR));
     add(std::move(collision_sprite));
 }

--- a/src/client/rendering/RenderingController.cpp
+++ b/src/client/rendering/RenderingController.cpp
@@ -71,7 +71,7 @@ void RenderingController::drawNotStarted() {
 
 void RenderingController::drawPlaying() {
     m_window.clear(sf::Color::Green);
-    m_buffer.clear(BACKGROUND_COLOR);
+    m_buffer.clear(RenderingDef::BACKGROUND_COLOR);
 
     // Draw game from player view
     m_window.setView(m_playerView);

--- a/src/common/objects/Group.cpp
+++ b/src/common/objects/Group.cpp
@@ -20,8 +20,7 @@ Group::~Group() {
 
 void Group::draw(sf::RenderTarget& render_target) {
     setOutlineThickness(0.f);
-
-    sf::Color outline_color = sf::Color::White;
+    sf::Color outline_color = RenderingDef::DEFAULT_GROUP_OUTLINE_COLOR;
 
     if (m_joinable) {
         setOutlineThickness(1.f);
@@ -30,15 +29,13 @@ void Group::draw(sf::RenderTarget& render_target) {
     // TODO(sourenp): This was only included for debugging purposes. Remove eventually.
     if (m_ungroup) {
         setOutlineThickness(1.f);
-        outline_color = sf::Color::Blue;
+        outline_color = RenderingDef::UNGROUP_COLOR;
     }
-
     setOutlineColor(outline_color);
 
     CircleGameObject::draw(render_target);
-
     m_directionArrow.draw(render_target, getRadius(), getPosition(), getVelocity(),
-                          m_targetDirections, sf::Color::White, m_isActive);
+                          m_targetDirections, RenderingDef::DIRECTION_ARROW_COLOR, m_isActive);
 }
 
 GroupUpdate Group::getUpdate() {

--- a/src/common/objects/Mine.cpp
+++ b/src/common/objects/Mine.cpp
@@ -23,7 +23,7 @@ Mine::Mine(uint32_t id, sf::Vector2f position, float size, sf::Color color,
     CircleGameObject(id, position, size, color, pc, rs, std::numeric_limits<float>::infinity(),
                      false),
     m_resourceType(resource_type) {
-    setTexture(RenderingDef::TextureKey::mine_pattern);
+    // setTexture(RenderingDef::TextureKey::mine_pattern);
 }
 
 Mine::~Mine() {

--- a/src/common/rendering/DirectionArrows.cpp
+++ b/src/common/rendering/DirectionArrows.cpp
@@ -10,6 +10,7 @@ const float MIN_SPEED = 1.f;            // Minimum speed at which velocity arrow
 const float TWO_MINUS_SQRT_3 = 0.2679f; // 2 - sqrt(3);
 const float TARGET_ALPHA = 0.5;         // How much to fade target arrows
 const float ARROW_SIZE = 6.f;           // Size of the triangle's base
+const float DISTANCE_FROM_EDGE = 1.f;   // Additional distance from cricle's edge
 
 DirectionArrows::DirectionArrows() : m_velocityTriangle(0, 3) {
     m_targetTriangles.reserve(MAX_PLAYER_COUNT);
@@ -85,5 +86,5 @@ void DirectionArrows::positionTriangle(sf::CircleShape& triangle, sf::Vector2f d
     triangle.setPosition(position.x + radius, position.y + radius);
 
     // Move to edge of circle
-    triangle.move(direction * radius + direction * (TWO_MINUS_SQRT_3 * size));
+    triangle.move(direction * (radius + (TWO_MINUS_SQRT_3 * size) + DISTANCE_FROM_EDGE));
 }

--- a/src/common/rendering/RenderingDef.hpp
+++ b/src/common/rendering/RenderingDef.hpp
@@ -16,17 +16,31 @@ namespace RenderingDef {
         ShaderKey key = ShaderKey::none;
         std::shared_ptr<sf::Shader> shader = nullptr;
     };
+
+    // Group colors
+    const sf::Color DEFAULT_GROUP_COLOR(sf::Color::Transparent);
+    const sf::Color DEFAULT_GROUP_OUTLINE_COLOR(sf::Color::Black);
     const sf::Color JOINABLE_COLOR(227, 102, 68);
+    const sf::Color UNGROUP_COLOR(sf::Color::Blue);
+    const sf::Color DIRECTION_ARROW_COLOR(63, 154, 233);
+
+    // Resource colors
     const sf::Color DARKEST_COLOR(66, 118, 118);
     const sf::Color DARK_COLOR(63, 157, 130);
     const sf::Color LIGHT_COLOR(161, 205, 115);
     const sf::Color LIGHTEST_COLOR(236, 219, 96);
+
+    // Mine colors
+    const sf::Color DEFAULT_MINE_COLOR(sf::Color::Red);
+    const sf::Color EMPTY_MINE_COLOR(155, 155, 155);
     const std::array<sf::Color, RESOURCE_TYPE_COUNT> MINE_COLORS = {
         RenderingDef::DARKEST_COLOR, RenderingDef::DARK_COLOR, RenderingDef::LIGHT_COLOR,
         RenderingDef::LIGHTEST_COLOR};
-    const sf::Color EMPTY_MINE_COLOR = sf::Color::White;
-    const sf::Color DEFAULT_GROUP_COLOR = sf::Color::Transparent;
-    const sf::Color DEFAULT_MINE_COLOR = sf::Color::White;
+
+    // Misc colors
+    const sf::Color BACKGROUND_COLOR(203, 219, 252);
+    const sf::Color COLLISION_ANIMATION_COLOR(sf::Color::Yellow);
+
 }; // namespace RenderingDef
 
 #endif /* RenderingDef_hpp */

--- a/src/common/util/game_settings.hpp
+++ b/src/common/util/game_settings.hpp
@@ -23,8 +23,7 @@ const InputDef::InputKeys INPUT_KEYS = {
 /* Game Logic */
 const sf::Vector2f GAME_SIZE(2688 * 4, 1512 * 4);
 const sf::Vector2f WINDOW_RESOLUTION(2688, 1512);
-const float GAME_SCALE = 1.f;
-const sf::Color BACKGROUND_COLOR(sf::Color::Black);
+const float GAME_SCALE = 1.5f;
 
 const bool USE_SHADER = true;
 const bool USE_INTERPOLATION_REPLAY = false;
@@ -35,7 +34,7 @@ const float GROUP_START_OFFSET_X = 20.f;
 const float GROUP_START_OFFSET_Y = 20.f;
 const float MINE_START_OFFSET_X = 50.f;
 const float MINE_START_OFFSET_Y = 200.f;
-const float GROUP_MEMBER_SIZE = 10.f;
+const float GROUP_MEMBER_SIZE = 14.f;
 const float MINE_SIZE = 80.f;
 const float GROUP_SPEED = 100.f;
 const uint32_t MINE_RESOURCE_COUNT = 1;

--- a/tests/client/rendering/tests-AnimatedSprite.cpp
+++ b/tests/client/rendering/tests-AnimatedSprite.cpp
@@ -8,7 +8,7 @@ SCENARIO("AnimatedSprite is created and animation completed",
         sf::Texture texture;
         texture.loadFromFile("resources/images/test.png");
         AnimatedSprite animated_sprite =
-            AnimatedSprite(texture, {3, 3}, 200, {100.f, 100.f}, {1.f, 1.f});
+            AnimatedSprite(texture, {3, 3}, 200, {100.f, 100.f}, {1.f, 1.f}, sf::Color::White);
         WHEN("is updated one time at 100ms") {
             animated_sprite.update(100);
             REQUIRE(animated_sprite.isDone() == false);

--- a/tests/client/rendering/tests-AnimationController.cpp
+++ b/tests/client/rendering/tests-AnimationController.cpp
@@ -9,7 +9,7 @@ SCENARIO("AnimatedSprite is added to AnimationController and removed on completi
         sf::Texture texture;
         texture.loadFromFile("resources/images/test.png");
         auto animated_sprite = std::unique_ptr<AnimatedSprite>(
-            new AnimatedSprite(texture, {6, 1}, 200, {100.f, 100.f}, {1.f, 1.f}));
+            new AnimatedSprite(texture, {6, 1}, 200, {100.f, 100.f}, {1.f, 1.f}, sf::Color::Red));
         ResourceStore resource_store;
         AnimationController animation_controller(resource_store);
         animation_controller.add(std::move(animated_sprite));


### PR DESCRIPTION
**Description**

Create constants for graphics.

*RenderingDef.hpp*
```cpp
// Group colors
const sf::Color DEFAULT_GROUP_COLOR(sf::Color::Transparent);
const sf::Color DEFAULT_GROUP_OUTLINE_COLOR(sf::Color::Black);
const sf::Color JOINABLE_COLOR(227, 102, 68);
const sf::Color UNGROUP_COLOR(sf::Color::Blue);
const sf::Color DIRECTION_ARROW_COLOR(63, 154, 233);

// Resource colors
const sf::Color DARKEST_COLOR(66, 118, 118);
const sf::Color DARK_COLOR(63, 157, 130);
const sf::Color LIGHT_COLOR(161, 205, 115);
const sf::Color LIGHTEST_COLOR(236, 219, 96);

// Mine colors
const sf::Color DEFAULT_MINE_COLOR(sf::Color::Red);
const sf::Color EMPTY_MINE_COLOR(155, 155, 155);
const std::array<sf::Color, RESOURCE_TYPE_COUNT> MINE_COLORS = {
    RenderingDef::DARKEST_COLOR, RenderingDef::DARK_COLOR, RenderingDef::LIGHT_COLOR,
    RenderingDef::LIGHTEST_COLOR};

// Misc colors
const sf::Color BACKGROUND_COLOR(203, 219, 252);
const sf::Color COLLISION_ANIMATION_COLOR(sf::Color::Yellow);
```


**Fixes**

Nothing

**Commits**


[fcc1d09] Create constants for graphics
 