### PR TITLE
Cmake debug and release flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
   - make install -j
   # Cmake
   - mkdir -p ${TRAVIS_BUILD_DIR}/build && cd ${TRAVIS_BUILD_DIR}/build
-  - cmake -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/usr -DCMAKE_CXX_FLAGS="-I${TRAVIS_BUILD_DIR}/usr/include" .. && cmake -LA ..
+  - cmake -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/usr -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-I${TRAVIS_BUILD_DIR}/usr/include" .. && cmake -LA ..
   - make -j VERBOSE=1
   - cd ..
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@ project(Ungroup VERSION 1.0 LANGUAGES CXX)
 set(CMAKE_CXX_COMPILER "clang++")
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -g -fsanitize=address -fno-omit-frame-pointer")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -g -fsanitize=address -fno-omit-frame-pointer")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 
 # find sfml
 set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Created by [@sourenp](https://github.com/SourenP) and [@copacetic](https://githu
 3. Configure and build:
 ```
 // With ninja (faster, colorless)
-cmake -GNinja -S . -B build
+cmake -DCMAKE_BUILD_TYPE=Release -GNinja -S . -B build
 ninja -C build
 
 // Without ninja (slower, colorful)
-cmake -S . -B build
+cmake -DCMAKE_BUILD_TYPE=Release -S . -B build
 cmake --build build -- -j
 ```
 4. Run server and client in seperate terminals:
@@ -66,9 +66,13 @@ To run tests, after building, run:
 
 ### Debugging
 
-#### Travis CI Debug Build
+#### Compile in debug mode
 
-Run this command to enable debug mode on a specific build: https://gist.github.com/SourenP/3ae15ba0e634a3e0ccceebbb7a27a391
+To compile in debug mode add the flag `-DCMAKE_BUILD_TYPE=Debug`:
+```
+cmake -DCMAKE_BUILD_TYPE=Debug -S . -B build
+cmake --build build -- -j
+```
 
 #### Vscode lldb
 
@@ -94,6 +98,11 @@ Debug build:
 Debug run:
 - Set breakpoints
 - Run `(lldb) Launch ug-server` and/or `(lldb) Launch ug-client` via the debug tab.
+
+#### Travis CI Debug Build
+
+Run this command to enable debug mode on a specific build: https://gist.github.com/SourenP/3ae15ba0e634a3e0ccceebbb7a27a391
+
 
 ## Resources
 


### PR DESCRIPTION
**Description**

Configure `CMakeLists.txt` to add the flags `-Wall -g -fsanitize=address -fno-omit-frame-pointer` in debug mode.

I tested the speeds of the release and debug builds and didn't notice a big difference:
```
cmake -DCMAKE_BUILD_TYPE=Debug -S . -B build
cmake --build build -- -j  128.69s user 9.32s system 202% cpu 1:08.16 total

cmake -DCMAKE_BUILD_TYPE=Release -S . -B build
cmake --build build -- -j  130.05s user 7.21s system 257% cpu 53.341 totall
```

**Fixes**

Fixes  #78

**Commits**

[f3d4f8e] Cmake debug and release flags

[ade3b65] Travis compile debug build
 
 