### PR TITLE
Enforce max velocity

### DIFF
--- a/src/common/objects/CircleRigidBody.cpp
+++ b/src/common/objects/CircleRigidBody.cpp
@@ -33,6 +33,8 @@ void CircleRigidBody::setVelocity(sf::Vector2f velocity) {
 
     m_velocity = velocity;
     VectorUtil::clamp(m_velocity, PhysicsDef::MIN_VELOCITY, PhysicsDef::MAX_VELOCITY);
+
+    setTargetVelocity(velocity);
 }
 
 void CircleRigidBody::setTargetVelocity(sf::Vector2f target_velocity) {

--- a/src/common/objects/CircleRigidBody.hpp
+++ b/src/common/objects/CircleRigidBody.hpp
@@ -48,6 +48,7 @@ class CircleRigidBody : public GameObject {
         return m_targetVelocity;
     }
     void setVelocity(sf::Vector2f velocity);
+    void setTargetVelocity(sf::Vector2f target_velocity);
 
     void applyImpulse(const PhysicsDef::Impulse& impulse);
     void applyInput(sf::Vector2f input);

--- a/src/common/physics/PhysicsDef.hpp
+++ b/src/common/physics/PhysicsDef.hpp
@@ -9,6 +9,10 @@ namespace PhysicsDef {
         sf::Vector2f normal;
     };
     const float IMPULSE_MILTIPLIER = 3.f;
+    const float TRANSITION_SPEED = 10.f; // drag / friction
+    const float PLAYER_VELOCITY = 200.f;
+    const float MAX_VELOCITY = PLAYER_VELOCITY * 4.f;
+    const float MIN_VELOCITY = -MAX_VELOCITY;
 }; // namespace PhysicsDef
 
 #endif /* PhysicsDef_hpp */


### PR DESCRIPTION
**Description**

Enforce max velocity to avoid teleportation situations such as a circle bouncing between two other circles and getting *really* fast *really* quickly.
This also helps avoid circles jumping over each other. Our collision system doesn't detect continuous collision.

**Fixes**

Fixes #99

**Commits**

[b37f397] Enforce max velocity
- Max velocity is proportional to player movement speed. Currnetly 4x
- Move physics constants to PhyscisDef.hpp


[7404e5f] Fix bug where target velocity is not updated when velocity is set
 

