### PR TITLE
Display group players

### DIFF
--- a/src/client/rendering/DebugUIElement.cpp
+++ b/src/client/rendering/DebugUIElement.cpp
@@ -12,8 +12,8 @@ DebugUIElement::DebugUIElement(sf::Vector2u window_size, sf::Vector2f size, Alig
     m_windowSize(window_size), m_align(align), m_padding(padding) {
     m_text.setFont(*rs.getFont(RenderingDef::FontKey::monogram));
     m_text.setString("NO DATA");
-    m_text.setCharacterSize(50.f);
-    m_text.setFillColor(sf::Color::Cyan);
+    m_text.setCharacterSize(RenderingDef::DEBUG_UI_TEXT_SIZE);
+    m_text.setFillColor(RenderingDef::DEBUG_UI_TEXT_COLOR);
     m_text.setPosition(m_position);
 }
 

--- a/src/client/rendering/RenderingController.cpp
+++ b/src/client/rendering/RenderingController.cpp
@@ -1,5 +1,7 @@
 #include "RenderingController.hpp"
 
+#include "../../common/rendering/RenderingUtil.hpp"
+
 RenderingController::RenderingController(sf::RenderWindow& window, GameObjectController& goc,
                                          ResourceStore& rs) :
     m_window(window),
@@ -14,9 +16,7 @@ RenderingController::RenderingController(sf::RenderWindow& window, GameObjectCon
     m_buffer.setSmooth(false);
 
     m_bufferSprite = sf::Sprite(m_buffer.getTexture());
-    m_bufferScalingFactor = {GAME_SCALE * GAME_SIZE.x / WINDOW_RESOLUTION.x,
-                             GAME_SCALE * GAME_SIZE.y / WINDOW_RESOLUTION.y};
-    m_bufferSprite.setScale(m_bufferScalingFactor);
+    m_bufferSprite.setScale(GAME_SCALING_FACTOR);
 
     // Create views to draw GUI and player view
     m_windowView = sf::View(window_size / 2.f, window_size);
@@ -41,8 +41,8 @@ void RenderingController::postUpdate(const sf::Vector2f& player_position, const 
     m_playerPosition = player_position;
     m_uiData = ui_data;
 
-    sf::Vector2f player_view_position = {m_playerPosition.x * m_bufferScalingFactor.x,
-                                         m_playerPosition.y * m_bufferScalingFactor.y};
+    sf::Vector2f player_view_position = RenderingUtil::mapCoordToPixelScaled(
+        m_playerPosition, m_window, m_windowView, GAME_SCALING_FACTOR);
     m_playerView.setCenter(player_view_position);
     m_guiController.update(m_uiData);
 }
@@ -82,6 +82,7 @@ void RenderingController::drawPlaying() {
 
     // Draw GUI from window view
     m_window.setView(m_windowView);
+    m_gameObjectController.drawUI(m_window, m_playerView);
     m_guiController.draw(m_window);
 
     m_buffer.display();
@@ -91,10 +92,10 @@ void RenderingController::drawPlaying() {
 void RenderingController::drawGameOver() {
     m_window.clear(sf::Color::Red);
     m_winnerText.setString("WINNER: " + std::to_string(m_uiData.winner_player_id));
-    sf::FloatRect text_bounds = m_winnerText.getLocalBounds();
-    m_winnerText.setPosition(
-        (sf::Vector2f(m_window.getSize()) - sf::Vector2f(text_bounds.width, text_bounds.height)) /
-        2.f);
+    sf::FloatRect textRect = m_winnerText.getLocalBounds();
+    m_winnerText.setOrigin(textRect.left + textRect.width / 2.0f,
+                           textRect.top + textRect.height / 2.0f);
+    m_winnerText.setPosition(sf::Vector2f(m_window.getSize()) / 2.f);
     m_window.draw(m_winnerText);
     m_window.display();
 }

--- a/src/client/rendering/RenderingController.hpp
+++ b/src/client/rendering/RenderingController.hpp
@@ -33,9 +33,8 @@ class RenderingController {
     sf::RenderWindow& m_window;
     sf::View m_playerView; // View specific to player
     sf::View m_windowView; // View of window. Used to draw UI elements independent of player view.
-    sf::Vector2f m_bufferScalingFactor; // Amount by which game is scaled.
-    sf::RenderTexture m_buffer;         // Buffer onto which game is drawn offscreen.
-    sf::Sprite m_bufferSprite;          // Sprite used to draw m_buffer.
+    sf::RenderTexture m_buffer; // Buffer onto which game is drawn offscreen.
+    sf::Sprite m_bufferSprite;  // Sprite used to draw m_buffer.
 
     // Data needed for rendering
     UIData m_uiData;

--- a/src/client/rendering/ResourceUIElement.cpp
+++ b/src/client/rendering/ResourceUIElement.cpp
@@ -15,8 +15,8 @@ ResourceUIElement::ResourceUIElement(sf::Vector2u window_size, sf::Vector2f size
     m_windowSize(window_size), m_align(align), m_padding(padding) {
     m_text.setFont(*rs.getFont(RenderingDef::FontKey::monogram));
     m_text.setString("NO DATA");
-    m_text.setCharacterSize(60.f);
-    m_text.setFillColor(sf::Color::White);
+    m_text.setCharacterSize(RenderingDef::RESOURCE_UI_TEXT_SIZE);
+    m_text.setFillColor(RenderingDef::RESOURCE_UI_TEXT_COLOR);
     m_text.setPosition(m_position);
 }
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(common-lib
     factories/IdFactory.cpp
     resources/ResourceStore.cpp
     rendering/DirectionArrows.cpp
+    rendering/RenderingUtil.cpp
 )
 
 target_link_libraries(common-lib PUBLIC sfml-system sfml-graphics sfml-network)

--- a/src/common/rendering/RenderingDef.hpp
+++ b/src/common/rendering/RenderingDef.hpp
@@ -17,29 +17,37 @@ namespace RenderingDef {
         std::shared_ptr<sf::Shader> shader = nullptr;
     };
 
-    // Group colors
+    // Group
     const sf::Color DEFAULT_GROUP_COLOR(sf::Color::Transparent);
     const sf::Color DEFAULT_GROUP_OUTLINE_COLOR(sf::Color::Black);
     const sf::Color JOINABLE_COLOR(227, 102, 68);
     const sf::Color UNGROUP_COLOR(sf::Color::Blue);
     const sf::Color DIRECTION_ARROW_COLOR(63, 154, 233);
+    const sf::Color PLAYER_ID_TEXT_COLOR(sf::Color::Black);
+    const float PLAYER_ID_TEXT_SIZE(50.f);
 
-    // Resource colors
+    // Resource
     const sf::Color DARKEST_COLOR(66, 118, 118);
     const sf::Color DARK_COLOR(63, 157, 130);
     const sf::Color LIGHT_COLOR(161, 205, 115);
     const sf::Color LIGHTEST_COLOR(236, 219, 96);
 
-    // Mine colors
+    // Mine
     const sf::Color DEFAULT_MINE_COLOR(sf::Color::Red);
     const sf::Color EMPTY_MINE_COLOR(155, 155, 155);
-    const std::array<sf::Color, RESOURCE_TYPE_COUNT> MINE_COLORS = {
-        RenderingDef::DARKEST_COLOR, RenderingDef::DARK_COLOR, RenderingDef::LIGHT_COLOR,
-        RenderingDef::LIGHTEST_COLOR};
+    const std::array<sf::Color, RESOURCE_TYPE_COUNT>
+        MINE_COLORS({RenderingDef::DARKEST_COLOR, RenderingDef::DARK_COLOR,
+                     RenderingDef::LIGHT_COLOR, RenderingDef::LIGHTEST_COLOR});
 
-    // Misc colors
+    // Misc
     const sf::Color BACKGROUND_COLOR(203, 219, 252);
     const sf::Color COLLISION_ANIMATION_COLOR(sf::Color::Yellow);
+
+    // UI
+    const sf::Color RESOURCE_UI_TEXT_COLOR(sf::Color::Black);
+    const float RESOURCE_UI_TEXT_SIZE(60.f);
+    const sf::Color DEBUG_UI_TEXT_COLOR(sf::Color::Blue);
+    const float DEBUG_UI_TEXT_SIZE(50.f);
 
 }; // namespace RenderingDef
 

--- a/src/common/rendering/RenderingUtil.cpp
+++ b/src/common/rendering/RenderingUtil.cpp
@@ -1,0 +1,21 @@
+#include "RenderingUtil.hpp"
+
+#include <sstream>
+
+std::string RenderingUtil::idVecToStr(std::vector<uint32_t> ids, const std::string& seperator) {
+    std::stringstream ss;
+    for (size_t i = 0; i < ids.size(); ++i) {
+        if (i != 0)
+            ss << seperator;
+        ss << ids[i];
+    }
+    return ss.str();
+}
+
+sf::Vector2f RenderingUtil::mapCoordToPixelScaled(const sf::Vector2f& position,
+                                                  const sf::RenderWindow& window,
+                                                  const sf::View& view,
+                                                  const sf::Vector2f scaling_factor) {
+    return sf::Vector2f(window.mapCoordsToPixel(
+        {position.x * scaling_factor.x, position.y * scaling_factor.y}, view));
+}

--- a/src/common/rendering/RenderingUtil.hpp
+++ b/src/common/rendering/RenderingUtil.hpp
@@ -1,0 +1,22 @@
+#ifndef RenderingtUtil_hpp
+#define RenderingtUtil_hpp
+
+#include <string>
+#include <vector>
+
+#include <SFML/Graphics.hpp>
+
+namespace RenderingUtil {
+    /**
+     * Converts a list of ids to a string.
+     */
+    std::string idVecToStr(std::vector<uint32_t> ids, const std::string& seperator);
+
+    /**
+     * Same as SFML's mapCoordToPixel but applies a scaling factor.
+     */
+    sf::Vector2f mapCoordToPixelScaled(const sf::Vector2f& position, const sf::RenderWindow& window,
+                                       const sf::View& view, const sf::Vector2f scaling_factor);
+} // namespace RenderingUtil
+
+#endif /* RenderingtUtil_hpp */

--- a/src/common/systems/GameObjectController.cpp
+++ b/src/common/systems/GameObjectController.cpp
@@ -12,7 +12,8 @@ GameObjectController::GameObjectController(PhysicsController& physics_controller
                                            ResourceStore& resource_store) :
     m_gameObjectStore(physics_controller, resource_store),
     m_playerController(m_gameObjectStore.getPlayers()),
-    m_groupController(m_gameObjectStore.getGroups(), m_gameObjectStore.getPlayers()),
+    m_groupController(m_gameObjectStore.getGroups(), m_gameObjectStore.getPlayers(),
+                      resource_store),
     m_mineController(m_gameObjectStore.getMines(), m_resourceController) {
     addEventListeners();
 }
@@ -122,6 +123,10 @@ GameStateObject GameObjectController::getGameStateObject() {
 void GameObjectController::draw(sf::RenderTexture& buffer) {
     m_groupController.draw(buffer);
     m_mineController.draw(buffer);
+}
+
+void GameObjectController::drawUI(sf::RenderWindow& window, sf::View& player_view) {
+    m_groupController.drawUI(window, player_view);
 }
 
 sf::Vector2f GameObjectController::getPlayerPosition(uint32_t player_id) {

--- a/src/common/systems/GameObjectController.hpp
+++ b/src/common/systems/GameObjectController.hpp
@@ -22,7 +22,18 @@ class GameObjectController {
     uint32_t createPlayerWithGroup(uint32_t client_id);
     GameStateObject getGameStateObject();
     void applyGameStateObject(GameStateObject game_state_object);
+
+    /**
+     * Draw the game object's onto the scalable buffer;
+     */
     void draw(sf::RenderTexture& buffer);
+
+    /**
+     * Draw the game object specific UI onto the unscaled window.
+     * This is called after draw, so the UI is drawn over the game objects.
+     */
+    void drawUI(sf::RenderWindow& window, sf::View& player_view);
+
     sf::Vector2f getPlayerPosition(uint32_t player_id);
     std::array<uint32_t, RESOURCE_TYPE_COUNT> getPlayerResources(uint32_t player_id);
     std::pair<bool, uint32_t> getGameOver();

--- a/src/common/systems/GroupController.hpp
+++ b/src/common/systems/GroupController.hpp
@@ -43,7 +43,7 @@ class GroupController {
     /**
      * Draw the game object's onto the scalable buffer;
      */
-    void draw(sf::RenderTarget& target);
+    void draw(sf::RenderTarget& buffer);
 
     /**
      * Draw the game object specific UI onto the unscaled window.
@@ -74,7 +74,7 @@ class GroupController {
     void addEventListeners();
 
     /**
-     * Draws groups' player ids with text in the middle of each group.
+     * Draws groups' player ids as text at the cneter of each group.
      */
     void drawGroupPlayerIds(sf::RenderWindow& window, sf::View& player_view);
 

--- a/src/common/systems/GroupController.hpp
+++ b/src/common/systems/GroupController.hpp
@@ -35,12 +35,22 @@ sf::Packet& operator>>(sf::Packet& packet, GroupControllerUpdate& gcu);
 class GroupController {
   public:
     GroupController(std::vector<std::shared_ptr<Group>>& groups,
-                    std::vector<std::shared_ptr<Player>>& players);
+                    std::vector<std::shared_ptr<Player>>& players, ResourceStore& rs);
     ~GroupController(){};
     GroupController(const GroupController& temp_obj) = delete;
     GroupController& operator=(const GroupController& temp_obj) = delete;
 
+    /**
+     * Draw the game object's onto the scalable buffer;
+     */
     void draw(sf::RenderTarget& target);
+
+    /**
+     * Draw the game object specific UI onto the unscaled window.
+     * This is called after draw, so the UI is drawn over the game objects.
+     */
+    void drawUI(sf::RenderWindow& window, sf::View& player_view);
+
     void update();
     uint32_t createGroup(uint32_t player_id);
     void updatePostPhysics();
@@ -63,10 +73,17 @@ class GroupController {
     void removePlayer(uint32_t player_id);
     void addEventListeners();
 
+    /**
+     * Draws groups' player ids with text in the middle of each group.
+     */
+    void drawGroupPlayerIds(sf::RenderWindow& window, sf::View& player_view);
+
     std::vector<std::shared_ptr<Player>> m_players;
     std::vector<std::shared_ptr<Group>> m_groups;
+    std::vector<sf::Text> m_groupPlayerTexts;
     std::unordered_map<uint32_t, std::vector<uint32_t>> m_groupToPlayers;
     std::unordered_map<uint32_t, uint32_t> m_playerToGroup;
+    ResourceStore& m_resourceStore;
 
     size_t nextGroupIndex = 0;
 };

--- a/src/common/util/game_settings.hpp
+++ b/src/common/util/game_settings.hpp
@@ -24,6 +24,8 @@ const InputDef::InputKeys INPUT_KEYS = {
 const sf::Vector2f GAME_SIZE(2688 * 4, 1512 * 4);
 const sf::Vector2f WINDOW_RESOLUTION(2688, 1512);
 const float GAME_SCALE = 1.5f;
+const sf::Vector2f GAME_SCALING_FACTOR(GAME_SCALE* GAME_SIZE.x / WINDOW_RESOLUTION.x,
+                                       GAME_SCALE* GAME_SIZE.y / WINDOW_RESOLUTION.y);
 
 const bool USE_SHADER = true;
 const bool USE_INTERPOLATION_REPLAY = false;


### PR DESCRIPTION
**Description**

Display group players.
<img width="388" alt="Screen Shot 2019-12-08 at 6 30 35 PM" src="https://user-images.githubusercontent.com/3184499/70390907-db441280-19e8-11ea-966a-01c64522ac39.png">

**Fixes**

Fixes #129

**Commits**

[ee62e17] Draw group player ids on each group
- Create a new function called drawUI for GameObjectControllers that
draws game object specfic UI on top of each game object. These are drawn
onto the winow rather than the buffer so that they are not scaled.
- Move some rendering constants to RenderingDef
- Create RenderUtil for rendering utility functions

[8709a2a] Minor fix
 


