### PR TITLE
Group direction/intent lines

### DIFF
--- a/resources/shaders/voronoi.frag
+++ b/resources/shaders/voronoi.frag
@@ -28,10 +28,18 @@ void main() {
     // Cell colors
     const int COLOR_COUNT = 4;
     vec3 color_pool[COLOR_COUNT];
-    color_pool[0] = vec3(66. / 255., 118. / 255., 118. / 255.);
-    color_pool[1] = vec3(63. / 255., 157. / 255., 130. / 255.);
-    color_pool[2] = vec3(161. / 255., 205. / 255., 115. / 255.);
-    color_pool[3] = vec3(236. / 255., 219. / 255., 96. / 255.);
+
+    // Green palette
+    // color_pool[0] = vec3(66. / 255., 118. / 255., 118. / 255.);
+    // color_pool[1] = vec3(63. / 255., 157. / 255., 130. / 255.);
+    // color_pool[2] = vec3(161. / 255., 205. / 255., 115. / 255.);
+    // color_pool[3] = vec3(236. / 255., 219. / 255., 96. / 255.);
+
+    // Soft palette
+    color_pool[0] = vec3(159. / 255., 224. / 255., 246. / 255.);
+    color_pool[1] = vec3(243. / 255., 229. / 255., 154. / 255.);
+    color_pool[2] = vec3(243. / 255., 181. / 255., 155. / 255.);
+    color_pool[3] = vec3(243. / 255., 156. / 255., 156. / 255.);
 
     // Cell count
     const int MAX_CELL_COUNT = 100;

--- a/run.sh
+++ b/run.sh
@@ -1,16 +1,22 @@
 #!/bin/bash
+# You can exit all tmux windows at once by pressing CTRL+B and typing :kill-window
 
 ./build.sh
 
-# You can exit all tmux windows at once by pressing CTRL+B and typing :kill-window
+if [ "$1" != "" ]; then
+    CLIENT_COUNT=$1
+else
+    CLIENT_COUNT=2
+fi
 
 tmux new -s ungroup -d
 tmux rename-window -t ungroup game
 tmux send-keys -t ungroup './build/src/server/ug-server' C-m
-tmux split-window -v -t ungroup
-tmux send-keys -t ungroup './build/src/client/ug-client' C-m
-tmux split-window -v -t ungroup
-tmux send-keys -t ungroup './build/src/client/ug-client' C-m
+for (( i = 0; i < $CLIENT_COUNT; i++ ))
+do
+    tmux split-window -v -t ungroup
+    tmux send-keys -t ungroup './build/src/client/ug-client' C-m
+done
 tmux select-window -t ungroup:1
 tmux attach -t ungroup
 

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@
 if [ "$1" != "" ]; then
     CLIENT_COUNT=$1
 else
-    CLIENT_COUNT=2
+    CLIENT_COUNT=1
 fi
 
 tmux new -s ungroup -d

--- a/run.sh
+++ b/run.sh
@@ -3,6 +3,12 @@
 
 ./build.sh
 
+if [ $? -ne 0 ]
+then
+    echo "Build failed!"
+    exit 1
+fi
+
 if [ "$1" != "" ]; then
     CLIENT_COUNT=$1
 else

--- a/src/client/rendering/RenderingController.cpp
+++ b/src/client/rendering/RenderingController.cpp
@@ -5,8 +5,8 @@
 RenderingController::RenderingController(sf::RenderWindow& window, GameObjectController& goc,
                                          ResourceStore& rs) :
     m_window(window),
-    m_gameObjectController(goc), m_resourceStore(rs), m_animationController(m_resourceStore),
-    m_guiController(m_window.getSize(), m_resourceStore), m_uiData({}) {
+    m_uiData({}), m_gameObjectController(goc), m_resourceStore(rs),
+    m_animationController(m_resourceStore), m_guiController(m_window.getSize(), m_resourceStore) {
     sf::Vector2f window_size = sf::Vector2f(m_window.getSize());
 
     // Create buffer to draw game onto. Buffer can be scaled to give pixelated effect

--- a/src/client/rendering/RenderingController.hpp
+++ b/src/client/rendering/RenderingController.hpp
@@ -44,8 +44,8 @@ class RenderingController {
 
     GameObjectController& m_gameObjectController;
     ResourceStore& m_resourceStore;
-    GUIController m_guiController;
     AnimationController m_animationController;
+    GUIController m_guiController;
 };
 
 #endif /* RenderingController_hpp */

--- a/src/client/systems/InputController.cpp
+++ b/src/client/systems/InputController.cpp
@@ -1,8 +1,10 @@
 #include "InputController.hpp"
 
+#include <iostream>
+
 InputController::InputController(InputDef::InputKeys keys) :
-    m_inputKeys(keys), m_reliableInput{false, false}, m_unreliableInput{false, false, false, false,
-                                                                        false} {
+    m_inputKeys(keys), m_reliableInput{false, false}, m_unreliableInput{false, false, false,
+                                                                        false, false, false} {
 }
 
 std::pair<InputDef::ReliableInput, InputDef::UnreliableInput>
@@ -29,6 +31,7 @@ InputController::collectInputs(sf::RenderWindow& window) {
                 .toggle_right = sf::Keyboard::isKeyPressed(m_inputKeys.right),
                 .toggle_left = sf::Keyboard::isKeyPressed(m_inputKeys.left),
                 .toggle_stop = sf::Keyboard::isKeyPressed(m_inputKeys.stop),
+                .toggle_intent = sf::Keyboard::isKeyPressed(m_inputKeys.intent),
             };
         }
     }

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(common-lib
     factories/IdFactory.cpp
     resources/ResourceStore.cpp
     rendering/DirectionArrows.cpp
+    rendering/DirectionLines.cpp
     rendering/RenderingUtil.cpp
 )
 

--- a/src/common/objects/CircleGameObject.cpp
+++ b/src/common/objects/CircleGameObject.cpp
@@ -10,8 +10,8 @@ CircleGameObject::CircleGameObject(uint32_t id, sf::Vector2f position, float rad
     GameObject(id),
     m_circleShape(radius, RenderingDef::CIRCLE_POINT_COUNT),
     m_outlineShape(radius, RenderingDef::CIRCLE_POINT_COUNT),
-    m_circleRigidBody(pc.add(std::move(std::unique_ptr<CircleRigidBody>(
-        new CircleRigidBody(id, radius, position, mass, movable))))),
+    m_circleRigidBody(pc.add(std::unique_ptr<CircleRigidBody>(
+        new CircleRigidBody(id, radius, position, mass, movable)))),
     m_resourceStore(rs) {
     m_circleShape.setPosition(position);
     m_circleShape.setFillColor(color);

--- a/src/common/objects/Group.cpp
+++ b/src/common/objects/Group.cpp
@@ -11,7 +11,7 @@
 Group::Group(uint32_t id, sf::Vector2f position, sf::Color color, PhysicsController& pc,
              ResourceStore& rs) :
     CircleGameObject(id, position, 0.f, color, pc, rs, 0.f),
-    m_directionArrow() {
+    m_directionArrow(), m_directionLines() {
     setShader(RenderingDef::ShaderKey::voronoi);
 }
 
@@ -33,9 +33,16 @@ void Group::draw(sf::RenderTarget& render_target) {
     }
     setOutlineColor(outline_color);
 
+    std::vector<std::pair<sf::Vector2f, sf::Color>> direction_color_pairs;
+    direction_color_pairs.reserve(m_targetDirections.size());
+    for (auto& direction : m_targetDirections) {
+        direction_color_pairs.push_back(std::make_pair(direction, sf::Color(50, 50, 50)));
+    }
+    m_directionLines.draw(render_target, getRadius(), getPosition(), direction_color_pairs,
+                          m_isActive);
     CircleGameObject::draw(render_target);
-    m_directionArrow.draw(render_target, getRadius(), getPosition(), getVelocity(),
-                          m_targetDirections, RenderingDef::DIRECTION_ARROW_COLOR, m_isActive);
+    // m_directionArrow.draw(render_target, getRadius(), getPosition(), getVelocity(),
+    //                       m_targetDirections, RenderingDef::DIRECTION_ARROW_COLOR, m_isActive);
 }
 
 GroupUpdate Group::getUpdate() {

--- a/src/common/objects/Group.cpp
+++ b/src/common/objects/Group.cpp
@@ -19,35 +19,41 @@ Group::Group(uint32_t id, sf::Vector2f position, sf::Color color, PhysicsControl
 Group::~Group() {
 }
 
-void Group::draw(sf::RenderTarget& render_target) {
+void Group::draw(sf::RenderTarget& render_target, bool joinable, bool ungroup,
+                 std::vector<sf::Vector2f> player_directions,
+                 std::vector<ResourceType> player_intents) {
+
     setOutlineThickness(0.f);
     sf::Color outline_color = RenderingDef::DEFAULT_GROUP_OUTLINE_COLOR;
 
-    if (m_joinable) {
+    if (joinable) {
         setOutlineThickness(1.f);
         outline_color = RenderingDef::JOINABLE_COLOR;
     }
     // TODO(sourenp): This was only included for debugging purposes. Remove eventually.
-    if (m_ungroup) {
+    if (ungroup) {
         setOutlineThickness(1.f);
         outline_color = RenderingDef::UNGROUP_COLOR;
     }
     setOutlineColor(outline_color);
 
+    if (player_directions.size() != player_intents.size()) {
+        throw std::runtime_error("Size of player directions and intents should be the same.");
+    }
     std::vector<std::pair<sf::Vector2f, sf::Color>> direction_color_pairs;
-    direction_color_pairs.reserve(m_targetDirections.size());
-    for (auto& direction : m_targetDirections) {
+    direction_color_pairs.reserve(player_directions.size());
+    for (size_t i = 0; i < player_directions.size(); i++) {
         direction_color_pairs.push_back(
-            std::make_pair(direction, RenderingDef::DIRECTION_LINE_DEFAULT_COLOR));
+            std::make_pair(player_directions[i], RenderingDef::RESOURCE_COLORS[player_intents[i]]));
     }
 
-    if (SHOW_DIRECTION_ARROWS) {
+    if (SHOW_DIRECTION_LINES) {
         m_directionLines.draw(render_target, getRadius(), getPosition(), direction_color_pairs,
                               m_isActive);
     }
-    if (SHOW_DIRECTION_LINES) {
+    if (SHOW_DIRECTION_ARROWS) {
         m_directionArrow.draw(render_target, getRadius(), getPosition(), getVelocity(),
-                              m_targetDirections, RenderingDef::DIRECTION_ARROW_COLOR, m_isActive);
+                              player_directions, RenderingDef::DIRECTION_ARROW_COLOR, m_isActive);
     }
     CircleGameObject::draw(render_target);
 }
@@ -60,7 +66,6 @@ GroupUpdate Group::getUpdate() {
         .x_pos = position.x,
         .y_pos = position.y,
         .radius = getRadius(),
-        .joinable = getJoinable(),
         .shader_key = (sf::Uint32)m_shader.key,
     };
 
@@ -71,7 +76,6 @@ void Group::applyUpdate(GroupUpdate gu) {
     setActive(gu.is_active);
     setPosition(sf::Vector2f(gu.x_pos, gu.y_pos));
     setRadius(gu.radius);
-    setJoinable(gu.joinable);
     setShader((RenderingDef::ShaderKey)gu.shader_key);
 }
 
@@ -85,16 +89,14 @@ void Group::setDirection(sf::Vector2f direction) {
 
 sf::Packet& operator<<(sf::Packet& packet, const GroupUpdate& group_update) {
     packet << group_update.group_id << group_update.is_active << group_update.x_pos
-           << group_update.y_pos << group_update.radius << group_update.joinable
-           << group_update.shader_key;
+           << group_update.y_pos << group_update.radius << group_update.shader_key;
 
     return packet;
 }
 
 sf::Packet& operator>>(sf::Packet& packet, GroupUpdate& group_update) {
     packet >> group_update.group_id >> group_update.is_active >> group_update.x_pos >>
-        group_update.y_pos >> group_update.radius >> group_update.joinable >>
-        group_update.shader_key;
+        group_update.y_pos >> group_update.radius >> group_update.shader_key;
 
     return packet;
 }

--- a/src/common/objects/Group.cpp
+++ b/src/common/objects/Group.cpp
@@ -36,8 +36,10 @@ void Group::draw(sf::RenderTarget& render_target) {
     std::vector<std::pair<sf::Vector2f, sf::Color>> direction_color_pairs;
     direction_color_pairs.reserve(m_targetDirections.size());
     for (auto& direction : m_targetDirections) {
-        direction_color_pairs.push_back(std::make_pair(direction, sf::Color(50, 50, 50)));
+        direction_color_pairs.push_back(
+            std::make_pair(direction, RenderingDef::DIRECTION_LINE_DEFAULT_COLOR));
     }
+
     m_directionLines.draw(render_target, getRadius(), getPosition(), direction_color_pairs,
                           m_isActive);
     CircleGameObject::draw(render_target);

--- a/src/common/objects/Group.cpp
+++ b/src/common/objects/Group.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "../rendering/RenderingDef.hpp"
+#include "../util/game_settings.hpp"
 #include "Group.hpp"
 
 Group::Group(uint32_t id, sf::Vector2f position, sf::Color color, PhysicsController& pc,
@@ -40,11 +41,15 @@ void Group::draw(sf::RenderTarget& render_target) {
             std::make_pair(direction, RenderingDef::DIRECTION_LINE_DEFAULT_COLOR));
     }
 
-    m_directionLines.draw(render_target, getRadius(), getPosition(), direction_color_pairs,
-                          m_isActive);
+    if (SHOW_DIRECTION_ARROWS) {
+        m_directionLines.draw(render_target, getRadius(), getPosition(), direction_color_pairs,
+                              m_isActive);
+    }
+    if (SHOW_DIRECTION_LINES) {
+        m_directionArrow.draw(render_target, getRadius(), getPosition(), getVelocity(),
+                              m_targetDirections, RenderingDef::DIRECTION_ARROW_COLOR, m_isActive);
+    }
     CircleGameObject::draw(render_target);
-    // m_directionArrow.draw(render_target, getRadius(), getPosition(), getVelocity(),
-    //                       m_targetDirections, RenderingDef::DIRECTION_ARROW_COLOR, m_isActive);
 }
 
 GroupUpdate Group::getUpdate() {

--- a/src/common/objects/Group.hpp
+++ b/src/common/objects/Group.hpp
@@ -10,6 +10,7 @@
 
 #include "../physics/PhysicsController.hpp"
 #include "../rendering/DirectionArrows.hpp"
+#include "../rendering/DirectionLines.hpp"
 #include "../resources/ResourceStore.hpp"
 #include "CircleGameObject.hpp"
 #include "Player.hpp"
@@ -66,6 +67,7 @@ class Group : public CircleGameObject {
     std::vector<sf::Vector2f> m_targetDirections;
 
     DirectionArrows m_directionArrow;
+    DirectionLines m_directionLines;
 };
 
 #endif /* Group_hpp */

--- a/src/common/objects/Group.hpp
+++ b/src/common/objects/Group.hpp
@@ -36,36 +36,17 @@ class Group : public CircleGameObject {
     Group(const Group& temp_obj) = delete;            // TODO: define this
     Group& operator=(const Group& temp_obj) = delete; // TODO: define this
 
-    bool getJoinable() {
-        return m_joinable;
-    };
-    void setJoinable(bool joinable) {
-        m_joinable = joinable;
-    };
-    bool getUngroup() {
-        return m_ungroup;
-    };
-    void setUngroup(bool ungroup) {
-        m_ungroup = ungroup;
-    };
     void setDirection(sf::Vector2f direction);
-
-    void setTargetDirections(std::vector<sf::Vector2f> target_directions) {
-        m_targetDirections = target_directions;
-    }
-
     void setActive(bool active);
 
     GroupUpdate getUpdate();
     void applyUpdate(GroupUpdate gu);
 
-    void draw(sf::RenderTarget& render_target);
+    void draw(sf::RenderTarget& render_target, bool joinable, bool ungroup,
+              std::vector<sf::Vector2f> player_directions,
+              std::vector<ResourceType> player_intents);
 
   private:
-    bool m_joinable = false;
-    bool m_ungroup = false;
-    std::vector<sf::Vector2f> m_targetDirections;
-
     DirectionArrows m_directionArrow;
     DirectionLines m_directionLines;
 };

--- a/src/common/objects/Mine.cpp
+++ b/src/common/objects/Mine.cpp
@@ -33,7 +33,7 @@ void Mine::draw(sf::RenderTarget& render_target) {
     if (m_resourceCount == 0) {
         setColor(RenderingDef::EMPTY_MINE_COLOR);
     } else {
-        setColor(RenderingDef::MINE_COLORS[m_resourceType]);
+        setColor(RenderingDef::RESOURCE_COLORS[m_resourceType]);
     }
 
     CircleGameObject::draw(render_target);

--- a/src/common/objects/Player.cpp
+++ b/src/common/objects/Player.cpp
@@ -4,7 +4,7 @@
 
 #include "../util/network_util.hpp"
 
-Player::Player(uint32_t id) : GameObject(id), m_direction(0.0, 0.0), m_joinable(false) {
+Player::Player(uint32_t id) : GameObject(id), m_direction(0.0, 0.0) {
 }
 
 Player::~Player() {

--- a/src/common/objects/Player.hpp
+++ b/src/common/objects/Player.hpp
@@ -5,6 +5,7 @@
 #include <SFML/Network.hpp>
 #include <stdio.h>
 
+#include "../systems/ResourceController.hpp"
 #include "GameObject.hpp"
 
 struct PlayerUpdate {
@@ -41,14 +42,33 @@ class Player : public GameObject {
     bool getUngroup() const {
         return m_ungroup;
     };
+    ResourceType getIntent() const {
+        return m_intent;
+    }
+
+    void toggleUngroup(bool toggle) {
+        m_ungroup ^= toggle;
+    }
+
+    void toggleJoinable(bool toggle) {
+        m_joinable ^= toggle;
+    }
+
+    void toggleIntent(bool toggle) {
+        if (toggle) {
+            m_intent = ResourceType((m_intent + 1) % RESOURCE_TYPE_COUNT);
+        }
+    }
 
     PlayerUpdate getUpdate() const;
     void applyUpdate(PlayerUpdate pu);
 
   private:
     sf::Vector2f m_direction;
-    bool m_joinable = false;
-    bool m_ungroup = false;
+    bool m_joinable = false;                   // If player is joinable into a group.
+    bool m_ungroup = false;                    // If player wants to ungroup.
+    ResourceType m_intent = ResourceType::RED; // Resource player intends to collect. This is
+                                               // communicated to other players.
 };
 
 #endif /* Player_hpp */

--- a/src/common/physics/VectorUtil.hpp
+++ b/src/common/physics/VectorUtil.hpp
@@ -16,6 +16,11 @@ namespace VectorUtil {
     float dot(const sf::Vector2f& a, const sf::Vector2f& b);
     void clamp(sf::Vector2f& a, float min, float max);
     float angle(const sf::Vector2f& v);
+    struct vector_comparator {
+        bool operator()(sf::Vector2f lhs, sf::Vector2f rhs) const {
+            return lhs.x + 10.f * lhs.y < rhs.x + 10.f * rhs.y;
+        }
+    };
 } // namespace VectorUtil
 
 #endif /* VectorUtil_hpp */

--- a/src/common/rendering/DirectionArrows.hpp
+++ b/src/common/rendering/DirectionArrows.hpp
@@ -1,5 +1,5 @@
 /**
- * Draws arrows around the edge of a (not drawn) circle.
+ * Draws arrows around the edge of a circle. The circle itself is not drawn.
  *
  * This class is specifically written for a circle with a velocity and target directions so it's
  * optimized to draw those. It will draw one velocity arrow and many others, in a lighter shade,

--- a/src/common/rendering/DirectionLines.cpp
+++ b/src/common/rendering/DirectionLines.cpp
@@ -6,13 +6,6 @@
 #include "../rendering/RenderingUtil.hpp"
 #include "../util/game_settings.hpp"
 
-DirectionLines::DirectionLines() {
-    m_lines.reserve(MAX_PLAYER_COUNT);
-    for (size_t i = 0; i < MAX_PLAYER_COUNT; i++) {
-        m_lines.push_back(sf::VertexArray(sf::LineStrip));
-    }
-}
-
 void DirectionLines::draw(
     sf::RenderTarget& render_target, float radius, sf::Vector2f position,
     const std::vector<std::pair<sf::Vector2f, sf::Color>>& direction_color_pairs, bool active) {
@@ -22,10 +15,9 @@ void DirectionLines::draw(
 
     // Create a map of direction to list of colors
     m_directionToColors.clear();
-    sf::Vector2f direction;
-    sf::Color color;
     for (auto& direction_and_color : direction_color_pairs) {
-        std::tie(direction, color) = direction_and_color;
+        const auto& direction = direction_and_color.first;
+        auto color = direction_and_color.second;
         if (direction == sf::Vector2f(0.f, 0.f)) {
             continue;
         }

--- a/src/common/rendering/DirectionLines.cpp
+++ b/src/common/rendering/DirectionLines.cpp
@@ -1,0 +1,69 @@
+#include "DirectionLines.hpp"
+
+#include <iostream>
+
+#include "../rendering/RenderingDef.hpp"
+#include "../util/game_settings.hpp"
+
+const float LINE_LENGTH_RADIUS_RATIO = 1.f;
+const float LINE_COLOR_ALPHA = 255 * 0.5f;
+const float DISTANCE_FROM_EDGE = 1.f; // Additional distance from cricle's edge
+
+DirectionLines::DirectionLines() {
+    m_lines.reserve(MAX_PLAYER_COUNT);
+    for (size_t i = 0; i < MAX_PLAYER_COUNT; i++) {
+        m_lines.push_back(sf::VertexArray(sf::LineStrip));
+    }
+}
+
+void DirectionLines::draw(
+    sf::RenderTarget& render_target, float radius, sf::Vector2f position,
+    const std::vector<std::pair<sf::Vector2f, sf::Color>>& direction_color_pairs, bool active) {
+    if (!active) {
+        return;
+    }
+
+    // Populate direction counts
+    m_directionToColors.clear();
+    sf::Vector2f direction;
+    sf::Color color;
+    for (auto& direction_and_color : direction_color_pairs) {
+        std::tie(direction, color) = direction_and_color;
+        if (direction == sf::Vector2f(0.f, 0.f)) {
+            continue;
+        }
+        if (m_directionToColors.count(direction) == 0) {
+            m_directionToColors[direction] = {color};
+        } else {
+            m_directionToColors[direction].push_back(color);
+        }
+    }
+
+    const float line_chunk_length =
+        radius * LINE_LENGTH_RADIUS_RATIO / direction_color_pairs.size();
+    const sf::Vector2f circle_center = position + sf::Vector2f(radius, radius);
+
+    size_t i = 0;
+    std::cout << m_directionToColors.size() << std::endl;
+    for (auto const& direction_colors : m_directionToColors) {
+        const auto& direction = direction_colors.first;
+        const auto& colors = direction_colors.second;
+
+        auto& line = m_lines[i];
+        line.clear();
+
+        for (size_t c = 0; c < colors.size(); c++) {
+            sf::Color color = colors[c];
+            color.a = LINE_COLOR_ALPHA;
+            sf::Vector2f start_point =
+                circle_center + direction * (radius + DISTANCE_FROM_EDGE + (line_chunk_length * c));
+            sf::Vector2f end_point = circle_center + direction * (radius + DISTANCE_FROM_EDGE +
+                                                                  (line_chunk_length * (c + 1)));
+            line.append(sf::Vertex(start_point, color));
+            line.append(sf::Vertex(end_point, color));
+        }
+
+        render_target.draw(line);
+        i++;
+    }
+}

--- a/src/common/rendering/DirectionLines.hpp
+++ b/src/common/rendering/DirectionLines.hpp
@@ -1,5 +1,8 @@
 /**
- * TODO
+ * Draws lines around the edge of a circle. The circle itself is not drawn.
+ * The lines represent the direction in which a player within a group wants to go and are colored in
+ * the player's desired resource.
+ * If several players point in the same direction then the line will be longer and have many colors.
  */
 
 #ifndef DirectionLines_hpp

--- a/src/common/rendering/DirectionLines.hpp
+++ b/src/common/rendering/DirectionLines.hpp
@@ -16,7 +16,7 @@
 
 class DirectionLines {
   public:
-    DirectionLines();
+    DirectionLines(){};
     ~DirectionLines(){};
 
     /**
@@ -32,7 +32,6 @@ class DirectionLines {
               bool active);
 
   private:
-    std::vector<sf::VertexArray> m_lines;
     std::map<sf::Vector2f, std::vector<sf::Color>, VectorUtil::vector_comparator>
         m_directionToColors;
 };

--- a/src/common/rendering/DirectionLines.hpp
+++ b/src/common/rendering/DirectionLines.hpp
@@ -1,0 +1,37 @@
+/**
+ * TODO
+ */
+
+#ifndef DirectionLines_hpp
+#define DirectionLines_hpp
+
+#include <unordered_map>
+
+#include <SFML/Graphics.hpp>
+
+#include "../physics/VectorUtil.hpp"
+
+class DirectionLines {
+  public:
+    DirectionLines();
+    ~DirectionLines(){};
+
+    /**
+     * Draws the target and velocity arrows if active.
+     *
+     * @radius: size of circle
+     * @position: position of circle
+     * @directions: list of directions
+     * @active: whether or not to draw the arrows
+     */
+    void draw(sf::RenderTarget& render_target, float radius, sf::Vector2f position,
+              const std::vector<std::pair<sf::Vector2f, sf::Color>>& direction_color_pairs,
+              bool active);
+
+  private:
+    std::vector<sf::VertexArray> m_lines;
+    std::map<sf::Vector2f, std::vector<sf::Color>, VectorUtil::vector_comparator>
+        m_directionToColors;
+};
+
+#endif /* DirectionLines_hpp */

--- a/src/common/rendering/RenderingDef.hpp
+++ b/src/common/rendering/RenderingDef.hpp
@@ -18,15 +18,26 @@ namespace RenderingDef {
     };
 
     /* Group */
+
     const sf::Color DEFAULT_GROUP_COLOR(sf::Color::Transparent);
     const sf::Color DEFAULT_GROUP_OUTLINE_COLOR(sf::Color::Black);
     const sf::Color JOINABLE_COLOR(0, 146, 199);
     const sf::Color UNGROUP_COLOR(sf::Color::Blue);
-    const sf::Color DIRECTION_ARROW_COLOR(63, 154, 233);
     const sf::Color PLAYER_ID_TEXT_COLOR(sf::Color::Black);
     const float PLAYER_ID_TEXT_SIZE(50.f);
 
+    /* Direction lines/arrows */
+
+    // Arrow
+    const sf::Color DIRECTION_ARROW_COLOR(63, 154, 233);
+    // Line
+    const sf::Color DIRECTION_LINE_DEFAULT_COLOR(120, 120, 120);
+    const float DIRECTION_LINE_STRIP_LENGTH(3.f);
+    const float DIRECTION_LINE_COLOR_ALPHA(255 * 0.5f);
+    const float DIRECTION_LINE_DISTANCE_FROM_EDGE(1.f);
+
     /* Resource */
+
     // Green palette
     // const sf::Color RESOURCE_A_COLOR(66, 118, 118);
     // const sf::Color RESOURCE_B_COLOR(63, 157, 130);
@@ -40,6 +51,7 @@ namespace RenderingDef {
     const sf::Color RESOURCE_D_COLOR(243, 156, 156);
 
     /* Mine */
+
     const sf::Color DEFAULT_MINE_COLOR(sf::Color::Red);
     const sf::Color EMPTY_MINE_COLOR(155, 155, 155);
     const std::array<sf::Color, RESOURCE_TYPE_COUNT>
@@ -47,10 +59,12 @@ namespace RenderingDef {
                      RenderingDef::RESOURCE_C_COLOR, RenderingDef::RESOURCE_D_COLOR});
 
     /* Misc */
+
     const sf::Color BACKGROUND_COLOR(sf::Color::White);
     const sf::Color COLLISION_ANIMATION_COLOR(0, 146, 199);
 
     /* UI */
+
     const sf::Color RESOURCE_UI_TEXT_COLOR(sf::Color::Black);
     const float RESOURCE_UI_TEXT_SIZE(60.f);
     const sf::Color DEBUG_UI_TEXT_COLOR(sf::Color::Blue);

--- a/src/common/rendering/RenderingDef.hpp
+++ b/src/common/rendering/RenderingDef.hpp
@@ -17,33 +17,40 @@ namespace RenderingDef {
         std::shared_ptr<sf::Shader> shader = nullptr;
     };
 
-    // Group
+    /* Group */
     const sf::Color DEFAULT_GROUP_COLOR(sf::Color::Transparent);
     const sf::Color DEFAULT_GROUP_OUTLINE_COLOR(sf::Color::Black);
-    const sf::Color JOINABLE_COLOR(227, 102, 68);
+    const sf::Color JOINABLE_COLOR(0, 146, 199);
     const sf::Color UNGROUP_COLOR(sf::Color::Blue);
     const sf::Color DIRECTION_ARROW_COLOR(63, 154, 233);
     const sf::Color PLAYER_ID_TEXT_COLOR(sf::Color::Black);
     const float PLAYER_ID_TEXT_SIZE(50.f);
 
-    // Resource
-    const sf::Color DARKEST_COLOR(66, 118, 118);
-    const sf::Color DARK_COLOR(63, 157, 130);
-    const sf::Color LIGHT_COLOR(161, 205, 115);
-    const sf::Color LIGHTEST_COLOR(236, 219, 96);
+    /* Resource */
+    // Green palette
+    // const sf::Color RESOURCE_A_COLOR(66, 118, 118);
+    // const sf::Color RESOURCE_B_COLOR(63, 157, 130);
+    // const sf::Color RESOURCE_C_COLOR(161, 205, 115);
+    // const sf::Color RESOURCE_D_COLOR(236, 219, 96);
 
-    // Mine
+    // Soft palette
+    const sf::Color RESOURCE_A_COLOR(159, 224, 246);
+    const sf::Color RESOURCE_B_COLOR(243, 229, 154);
+    const sf::Color RESOURCE_C_COLOR(243, 181, 155);
+    const sf::Color RESOURCE_D_COLOR(243, 156, 156);
+
+    /* Mine */
     const sf::Color DEFAULT_MINE_COLOR(sf::Color::Red);
     const sf::Color EMPTY_MINE_COLOR(155, 155, 155);
     const std::array<sf::Color, RESOURCE_TYPE_COUNT>
-        MINE_COLORS({RenderingDef::DARKEST_COLOR, RenderingDef::DARK_COLOR,
-                     RenderingDef::LIGHT_COLOR, RenderingDef::LIGHTEST_COLOR});
+        MINE_COLORS({RenderingDef::RESOURCE_A_COLOR, RenderingDef::RESOURCE_B_COLOR,
+                     RenderingDef::RESOURCE_C_COLOR, RenderingDef::RESOURCE_D_COLOR});
 
-    // Misc
-    const sf::Color BACKGROUND_COLOR(203, 219, 252);
-    const sf::Color COLLISION_ANIMATION_COLOR(sf::Color::Yellow);
+    /* Misc */
+    const sf::Color BACKGROUND_COLOR(sf::Color::White);
+    const sf::Color COLLISION_ANIMATION_COLOR(0, 146, 199);
 
-    // UI
+    /* UI */
     const sf::Color RESOURCE_UI_TEXT_COLOR(sf::Color::Black);
     const float RESOURCE_UI_TEXT_SIZE(60.f);
     const sf::Color DEBUG_UI_TEXT_COLOR(sf::Color::Blue);

--- a/src/common/rendering/RenderingDef.hpp
+++ b/src/common/rendering/RenderingDef.hpp
@@ -30,6 +30,7 @@ namespace RenderingDef {
 
     // Arrow
     const sf::Color DIRECTION_ARROW_COLOR(63, 154, 233);
+
     // Line
     const sf::Color DIRECTION_LINE_DEFAULT_COLOR(120, 120, 120);
     const float DIRECTION_LINE_STRIP_LENGTH(3.f);
@@ -55,8 +56,8 @@ namespace RenderingDef {
     const sf::Color DEFAULT_MINE_COLOR(sf::Color::Red);
     const sf::Color EMPTY_MINE_COLOR(155, 155, 155);
     const std::array<sf::Color, RESOURCE_TYPE_COUNT>
-        MINE_COLORS({RenderingDef::RESOURCE_A_COLOR, RenderingDef::RESOURCE_B_COLOR,
-                     RenderingDef::RESOURCE_C_COLOR, RenderingDef::RESOURCE_D_COLOR});
+        RESOURCE_COLORS({RenderingDef::RESOURCE_A_COLOR, RenderingDef::RESOURCE_B_COLOR,
+                         RenderingDef::RESOURCE_C_COLOR, RenderingDef::RESOURCE_D_COLOR});
 
     /* Misc */
 

--- a/src/common/rendering/RenderingUtil.cpp
+++ b/src/common/rendering/RenderingUtil.cpp
@@ -1,5 +1,7 @@
 #include "RenderingUtil.hpp"
 
+#include "../physics/VectorUtil.hpp"
+
 #include <sstream>
 
 std::string RenderingUtil::idVecToStr(std::vector<uint32_t> ids, const std::string& seperator) {
@@ -18,4 +20,21 @@ sf::Vector2f RenderingUtil::mapCoordToPixelScaled(const sf::Vector2f& position,
                                                   const sf::Vector2f scaling_factor) {
     return sf::Vector2f(window.mapCoordsToPixel(
         {position.x * scaling_factor.x, position.y * scaling_factor.y}, view));
+}
+
+/**
+ * We can't draw one point for each color because the renderer will draw a color gradient between
+ * the lines. Instead we draw to points of the same color at the ends of each strip.
+ */
+sf::VertexArray RenderingUtil::strippedLine(sf::Vector2f start_point, sf::Vector2f direction,
+                                            float strip_length, std::vector<sf::Color> colors) {
+    sf::VertexArray vertex_array(sf::LineStrip, colors.size() * 2);
+    sf::Vector2f strip_start_point, strip_end_point;
+    for (size_t c = 0; c < colors.size(); c++) {
+        strip_start_point = start_point + direction * strip_length * static_cast<float>(c);
+        strip_end_point = strip_start_point + direction * strip_length;
+        vertex_array[2 * c] = sf::Vertex(strip_start_point, colors[c]);
+        vertex_array[2 * c + 1] = sf::Vertex(strip_end_point, colors[c]);
+    }
+    return vertex_array;
 }

--- a/src/common/rendering/RenderingUtil.hpp
+++ b/src/common/rendering/RenderingUtil.hpp
@@ -17,6 +17,16 @@ namespace RenderingUtil {
      */
     sf::Vector2f mapCoordToPixelScaled(const sf::Vector2f& position, const sf::RenderWindow& window,
                                        const sf::View& view, const sf::Vector2f scaling_factor);
+
+    /**
+     * Creates a line that is colored evenly in strips.
+     * @start_point: starting point of line.
+     * @direction: direction of line, assumed to be a unit vector.
+     * @strip_length: length of each individaul strip.
+     * @colors: list of colors. The length of the line will be (colors.size() * strip_length).
+     */
+    sf::VertexArray strippedLine(sf::Vector2f start_point, sf::Vector2f direction,
+                                 float strip_length, std::vector<sf::Color> colors);
 } // namespace RenderingUtil
 
 #endif /* RenderingtUtil_hpp */

--- a/src/common/systems/GameObjectController.hpp
+++ b/src/common/systems/GameObjectController.hpp
@@ -46,8 +46,8 @@ class GameObjectController {
 
     ResourceController m_resourceController;
     GameObjectStore m_gameObjectStore;
-    GroupController m_groupController;
     PlayerController m_playerController;
+    GroupController m_groupController;
     MineController m_mineController;
 };
 

--- a/src/common/systems/GroupController.cpp
+++ b/src/common/systems/GroupController.cpp
@@ -19,7 +19,7 @@ GroupController::GroupController(std::vector<std::shared_ptr<Group>>& groups,
     m_players(players),
     m_groups(groups), m_resourceStore(rs) {
     addEventListeners();
-    for (auto& group : m_groups) {
+    for (size_t i = 0; i < m_groups.size(); i++) {
         sf::Text player_text("", *m_resourceStore.getFont(RenderingDef::FontKey::monogram),
                              RenderingDef::PLAYER_ID_TEXT_SIZE);
         player_text.setFillColor(RenderingDef::PLAYER_ID_TEXT_COLOR);
@@ -192,7 +192,7 @@ void GroupController::updateGroup(std::shared_ptr<Group>& group) {
     // Group's velocity is an accumilation of it's members directions
     sf::Vector2f group_vel = std::accumulate(
         player_directions.begin(), player_directions.end(), sf::Vector2f(0.f, 0.f),
-        [this](sf::Vector2f curr_vel, sf::Vector2f player_dir) { return curr_vel + player_dir; });
+        [](sf::Vector2f curr_vel, sf::Vector2f player_dir) { return curr_vel + player_dir; });
     group->setDirection(group_vel);
 
     // Group is joinable if any member player is joinable

--- a/src/common/systems/GroupController.cpp
+++ b/src/common/systems/GroupController.cpp
@@ -268,9 +268,6 @@ void GroupController::joinGroups(uint32_t circle_a_id, uint32_t circle_b_id) {
         return;
     }
 
-    Group& group_a = getGroup(circle_a_id);
-    Group& group_b = getGroup(circle_b_id);
-
     if (!getJoinable(circle_a_id) || !getJoinable(circle_b_id)) {
         return;
     }

--- a/src/common/systems/GroupController.hpp
+++ b/src/common/systems/GroupController.hpp
@@ -72,6 +72,18 @@ class GroupController {
     void updateGroup(std::shared_ptr<Group>& group);
     void removePlayer(uint32_t player_id);
     void addEventListeners();
+    std::vector<sf::Vector2f> getPlayerDirections(uint32_t group_id);
+    std::vector<ResourceType> getPlayerIntents(uint32_t group_id);
+
+    /**
+     * Group is ungroup if any member player is ungroup
+     */
+    bool getUngroup(uint32_t group_id);
+
+    /**
+     * Group is joinable if any member player is joinable
+     */
+    bool getJoinable(uint32_t group_id);
 
     /**
      * Draws groups' player ids as text at the cneter of each group.

--- a/src/common/systems/PlayerController.cpp
+++ b/src/common/systems/PlayerController.cpp
@@ -47,17 +47,21 @@ void PlayerController::update(const InputDef::PlayerInputs& pi) {
     for (const auto& player_unreliable_input : pi.player_unreliable_inputs) {
         uint32_t player_id = player_unreliable_input.player_id;
         auto ui = player_unreliable_input.unreliable_input;
-        sf::Vector2f direction = Util::inputToDirection(
-            ui.toggle_up, ui.toggle_down, ui.toggle_right, ui.toggle_left, ui.toggle_stop);
-        getPlayer(player_id)->setDirection(direction);
+        auto player = getPlayer(player_id);
+
+        // Only set direction if direction input is present
+        if (ui.toggle_up || ui.toggle_down || ui.toggle_right || ui.toggle_left || ui.toggle_stop) {
+            player->setDirection(Util::inputToDirection(
+                ui.toggle_up, ui.toggle_down, ui.toggle_right, ui.toggle_left, ui.toggle_stop));
+        }
+        player->toggleIntent(ui.toggle_intent);
     }
     for (const auto& player_reliable_input : pi.player_reliable_inputs) {
         uint32_t player_id = player_reliable_input.player_id;
         auto player = getPlayer(player_id);
-        player->setJoinable(player->getJoinable() ^
-                            player_reliable_input.reliable_input.toggle_joinable);
-        player->setUngroup(player->getUngroup() ^
-                           player_reliable_input.reliable_input.toggle_ungroup);
+
+        player->toggleJoinable(player_reliable_input.reliable_input.toggle_joinable);
+        player->toggleUngroup(player_reliable_input.reliable_input.toggle_ungroup);
     }
 }
 

--- a/src/common/util/InputDef.cpp
+++ b/src/common/util/InputDef.cpp
@@ -2,12 +2,12 @@
 
 sf::Packet& operator<<(sf::Packet& packet, const InputDef::UnreliableInput& ui) {
     return packet << ui.toggle_up << ui.toggle_down << ui.toggle_right << ui.toggle_left
-                  << ui.toggle_stop;
+                  << ui.toggle_stop << ui.toggle_intent;
 }
 
 sf::Packet& operator>>(sf::Packet& packet, InputDef::UnreliableInput& ui) {
     return packet >> ui.toggle_up >> ui.toggle_down >> ui.toggle_right >> ui.toggle_left >>
-           ui.toggle_stop;
+           ui.toggle_stop >> ui.toggle_intent;
 }
 
 sf::Packet& operator<<(sf::Packet& packet, const InputDef::ReliableInput& ri) {

--- a/src/common/util/InputDef.hpp
+++ b/src/common/util/InputDef.hpp
@@ -6,7 +6,7 @@
 
 namespace InputDef {
     struct InputKeys {
-        sf::Keyboard::Key up, down, right, left, joinable, ungroup, stop;
+        sf::Keyboard::Key up, down, right, left, joinable, ungroup, stop, intent;
     };
 
     struct UnreliableInput {
@@ -15,15 +15,18 @@ namespace InputDef {
         bool toggle_right;
         bool toggle_left;
         bool toggle_stop;
+        bool toggle_intent;
         void setAll(bool value) {
             toggle_up = value;
             toggle_down = value;
             toggle_right = value;
             toggle_left = value;
             toggle_stop = value;
+            toggle_intent = value;
         };
         bool allFalse() {
-            return !toggle_up && !toggle_down && !toggle_right && !toggle_left && !toggle_stop;
+            return !toggle_up && !toggle_down && !toggle_right && !toggle_left && !toggle_stop &&
+                   !toggle_intent;
         };
     };
 

--- a/src/common/util/game_settings.hpp
+++ b/src/common/util/game_settings.hpp
@@ -23,7 +23,7 @@ const InputDef::InputKeys INPUT_KEYS = {
 /* Game Logic */
 const sf::Vector2f GAME_SIZE(2688 * 4, 1512 * 4);
 const sf::Vector2f WINDOW_RESOLUTION(2688, 1512);
-const float GAME_SCALE = 1.5f;
+const float GAME_SCALE = 3.f;
 const sf::Vector2f GAME_SCALING_FACTOR(GAME_SCALE* GAME_SIZE.x / WINDOW_RESOLUTION.x,
                                        GAME_SCALE* GAME_SIZE.y / WINDOW_RESOLUTION.y);
 
@@ -36,8 +36,8 @@ const float GROUP_START_OFFSET_X = 20.f;
 const float GROUP_START_OFFSET_Y = 20.f;
 const float MINE_START_OFFSET_X = 50.f;
 const float MINE_START_OFFSET_Y = 200.f;
-const float GROUP_MEMBER_SIZE = 14.f;
-const float MINE_SIZE = 80.f;
+const float GROUP_MEMBER_SIZE = 10.f;
+const float MINE_SIZE = 40.f;
 const float GROUP_SPEED = 100.f;
 const uint32_t MINE_RESOURCE_COUNT = 1;
 

--- a/src/common/util/game_settings.hpp
+++ b/src/common/util/game_settings.hpp
@@ -20,7 +20,6 @@ const InputDef::InputKeys INPUT_KEYS = {
     .stop = sf::Keyboard::Space,
 };
 
-/* Game Logic */
 const sf::Vector2f GAME_SIZE(2688 * 4, 1512 * 4);
 const sf::Vector2f WINDOW_RESOLUTION(2688, 1512);
 const float GAME_SCALE = 3.f;
@@ -28,6 +27,11 @@ const sf::Vector2f GAME_SCALING_FACTOR(GAME_SCALE* GAME_SIZE.x / WINDOW_RESOLUTI
                                        GAME_SCALE* GAME_SIZE.y / WINDOW_RESOLUTION.y);
 
 const bool USE_SHADER = true;
+const bool SHOW_DIRECTION_ARROWS = false;
+const bool SHOW_DIRECTION_LINES = true;
+
+/* Game Logic */
+
 const bool USE_INTERPOLATION_REPLAY = false;
 
 const int MAX_PLAYER_COUNT = 10;

--- a/src/common/util/game_settings.hpp
+++ b/src/common/util/game_settings.hpp
@@ -18,6 +18,7 @@ const InputDef::InputKeys INPUT_KEYS = {
     .joinable = sf::Keyboard::G,
     .ungroup = sf::Keyboard::Escape,
     .stop = sf::Keyboard::Space,
+    .intent = sf::Keyboard::E,
 };
 
 const sf::Vector2f GAME_SIZE(2688 * 4, 1512 * 4);


### PR DESCRIPTION
**Description**

Draws  lines around groups which point in members' directions and are colored in their intended resources.
If several players point in the same direction the line gets longer and shows in strips of color.

*Here you can see all five members of the group pointing in the same direction. Two of the players intend blue, one yellow, one orange and one red*
<img width="294" alt="Screen Shot 2019-12-12 at 9 20 18 PM" src="https://user-images.githubusercontent.com/3184499/70742715-947f5100-1d37-11ea-91e1-2a522ecb490d.png">

*An example with more members and directions*
<img width="243" alt="Screen Shot 2019-12-12 at 11 33 16 PM" src="https://user-images.githubusercontent.com/3184499/70742815-d1e3de80-1d37-11ea-8925-bca619684e5d.png">

!! Player desire is still WIP !!

**Fixes**

Fixes #138

**Commits**

[a22aa98 | b4d32c4] Set number of clients via command line parameter for run.sh

[9b3141b] Exit run.sh if build fails

[63a30e7] Draw direction lines

[6113738] Clean up direction line code
- Document
- Create a strippedLine utility function that creates the line
- Create constants for defining how the direction lines look

[7ea8580] Minor fixes
 
[5f5c6ed] Player resource intent input
- User can toggle through their intended resource using the E key
- Sync intent over network
- Pass intent to direction lines for strip coloring
- Refactor GroupController to remove state stored by Group which is
derived from player state. Instead compute these values using player
state when needed (e.g. draw).

[b6c2d01] Minor fix
 

