### PR TITLE
Show mine resource count

### DIFF
--- a/resources/shaders/voronoi_counts.frag
+++ b/resources/shaders/voronoi_counts.frag
@@ -18,16 +18,16 @@ uniform float u_resourceCounts[COLOR_COUNT]; // Order of resources needs to corr
                                              // colors in  color_pool.
 
 // Green palette
-const vec3 green_a = vec3(66. / 255., 118. / 255., 118. / 255.);
-const vec3 green_b = vec3(63. / 255., 157. / 255., 130. / 255.);
-const vec3 green_c = vec3(161. / 255., 205. / 255., 115. / 255.);
-const vec3 green_d = vec3(236. / 255., 219. / 255., 96. / 255.);
+const vec4 green_a = vec4(66. / 255., 118. / 255., 118. / 255., 1.);
+const vec4 green_b = vec4(63. / 255., 157. / 255., 130. / 255., 1.);
+const vec4 green_c = vec4(161. / 255., 205. / 255., 115. / 255., 1.);
+const vec4 green_d = vec4(236. / 255., 219. / 255., 96. / 255., 1.);
 
 // Soft palette
-const vec3 soft_a = vec3(159. / 255., 224. / 255., 246. / 255.);
-const vec3 soft_b = vec3(243. / 255., 229. / 255., 154. / 255.);
-const vec3 soft_c = vec3(243. / 255., 181. / 255., 155. / 255.);
-const vec3 soft_d = vec3(243. / 255., 156. / 255., 156. / 255.);
+const vec4 soft_a = vec4(159. / 255., 224. / 255., 246. / 255., 1.);
+const vec4 soft_b = vec4(243. / 255., 229. / 255., 154. / 255., 1.);
+const vec4 soft_c = vec4(243. / 255., 181. / 255., 155. / 255., 1.);
+const vec4 soft_d = vec4(243. / 255., 156. / 255., 156. / 255., 1.);
 
 vec2 random2(vec2 p) {
     return fract(sin(vec2(dot(p, vec2(127.1, 311.7)), dot(p, vec2(269.5, 183.3)))) * 43758.5453);
@@ -42,10 +42,10 @@ void main() {
     st *= u_resolution / (u_radius * 2.);
     st = fract(st);
 
-    vec3 color = vec3(.0);
+    vec4 color = vec4(1., 1., 1., .0);
 
     // Cell colors
-    vec3 color_pool[COLOR_COUNT];
+    vec4 color_pool[COLOR_COUNT];
     color_pool[0] = soft_a;
     color_pool[1] = soft_b;
     color_pool[2] = soft_c;
@@ -54,11 +54,11 @@ void main() {
     int CELL_COUNT = u_maxResources / RESOURCES_PER_CELL;
 
     /* Cell colors */
-    vec3 point_color[MAX_CELL_COUNT];
+    vec4 point_color[MAX_CELL_COUNT];
 
-    // Set all to white
+    // Set all to transparent
     for (int i = 0; i < u_maxResources; i++) {
-        point_color[i] = vec3(1.);
+        point_color[i] = vec4(1., 1., 1., 0.);
     }
 
     // Populate resources
@@ -80,7 +80,7 @@ void main() {
 
     float m_dist = 2.;  // minimun distance
     vec2 closest_point; // minimum position
-    vec3 closest_point_color = vec3(1.);
+    vec4 closest_point_color = vec4(1., 1., 1., 0.);
 
     // Iterate through the points positions
     for (int i = 0; i < CELL_COUNT; i++) {
@@ -99,5 +99,5 @@ void main() {
     // Set color to closest point color
     color = closest_point_color;
 
-    gl_FragColor = vec4(color, 1.0);
+    gl_FragColor = color;
 }

--- a/src/client/rendering/DrawableGroup.cpp
+++ b/src/client/rendering/DrawableGroup.cpp
@@ -54,23 +54,10 @@ void DrawableGroup::drawDirectionArrows(sf::RenderTarget& target, Group& group,
 
 void DrawableGroup::drawGroup(sf::RenderTarget& target, Group& group, bool joinable, bool ungroup,
                               const std::array<uint32_t, RESOURCE_TYPE_COUNT>& resource_counts) {
+
+    // Circle
     m_circleShape.setPosition(group.getPosition());
     m_circleShape.setRadius(group.getRadius());
-
-    m_outlineShape.setPosition(group.getPosition());
-    m_outlineShape.setRadius(group.getRadius());
-
-    m_outlineShape.setOutlineThickness(1.f);
-    sf::Color outline_color = RenderingDef::DEFAULT_GROUP_OUTLINE_COLOR;
-
-    if (joinable) {
-        outline_color = RenderingDef::JOINABLE_COLOR;
-    }
-
-    // TODO(sourenp): This was only included for debugging purposes. Remove eventually.
-    if (ungroup) {
-        outline_color = RenderingDef::UNGROUP_COLOR;
-    }
 
     if (m_shader.shader != nullptr && RenderingDef::USE_SHADERS) {
         std::copy(resource_counts.begin(), resource_counts.end(), m_resourceCounts);
@@ -84,12 +71,27 @@ void DrawableGroup::drawGroup(sf::RenderTarget& target, Group& group, bool joina
         m_shader.shader->setUniform("u_maxResources", total_resource_count);
     }
 
-    m_outlineShape.setOutlineColor(outline_color);
-
     if (m_shader.shader != nullptr && RenderingDef::USE_SHADERS) {
         target.draw(m_circleShape, m_shader.shader.get());
     } else {
         target.draw(m_circleShape);
     }
+
+    // Outline
+    m_outlineShape.setPosition(group.getPosition());
+    m_outlineShape.setRadius(group.getRadius());
+    m_outlineShape.setOutlineThickness(1.f);
+    sf::Color outline_color = RenderingDef::DEFAULT_GROUP_OUTLINE_COLOR;
+
+    if (joinable) {
+        outline_color = RenderingDef::JOINABLE_COLOR;
+    }
+
+    // TODO(sourenp): This was only included for debugging purposes. Remove eventually.
+    if (ungroup) {
+        outline_color = RenderingDef::UNGROUP_COLOR;
+    }
+
+    m_outlineShape.setOutlineColor(outline_color);
     target.draw(m_outlineShape);
 }

--- a/src/client/rendering/DrawableMine.cpp
+++ b/src/client/rendering/DrawableMine.cpp
@@ -1,24 +1,48 @@
 #include "DrawableMine.hpp"
 
+#include "../../common/util/game_settings.hpp"
+#include <numeric>
+
 #include "RenderingDef.hpp"
 
 DrawableMine::DrawableMine(ResourceStore& rs) : DrawableCircle(rs) {
-    setTexture(RenderingDef::TextureKey::mine_pattern);
+    // setTexture(RenderingDef::TextureKey::mine_pattern);
+    m_outlineShape.setOutlineThickness(2.f);
+    setShader(RenderingDef::ShaderKey::voronoi_counts);
 }
 
-void DrawableMine::draw(sf::RenderTarget& target, Mine& mine, uint32_t resource_count) {
+void DrawableMine::draw(sf::RenderTarget& target, Mine& mine, uint32_t resource_count,
+                        const std::array<uint32_t, RESOURCE_TYPE_COUNT>& resource_counts) {
     if (!mine.isActive()) {
         return;
     }
 
+    // Circle
     m_circleShape.setPosition(mine.getPosition());
     m_circleShape.setRadius(mine.getRadius());
 
-    if (resource_count == 0) {
-        m_circleShape.setFillColor(RenderingDef::EMPTY_MINE_COLOR);
-    } else {
-        m_circleShape.setFillColor(RenderingDef::RESOURCE_COLORS[mine.getResourceType()]);
+    if (m_shader.shader != nullptr && RenderingDef::USE_SHADERS) {
+        std::copy(resource_counts.begin(), resource_counts.end(), m_resourceCounts);
+        int total_resource_count = mine.getResourceCapacity();
+        m_shader.shader->setUniform("u_resolution", sf::Vector2f(WINDOW_RESOLUTION));
+        m_shader.shader->setUniform("u_position", mine.getPosition());
+        m_shader.shader->setUniform("u_radius", mine.getRadius());
+        m_shader.shader->setUniform("u_time", m_shaderClock.getElapsedTime().asSeconds());
+        m_shader.shader->setUniformArray("u_resourceCounts", m_resourceCounts, RESOURCE_TYPE_COUNT);
+        m_shader.shader->setUniform("u_maxResources", total_resource_count);
     }
 
-    target.draw(m_circleShape);
+    if (m_shader.shader != nullptr && RenderingDef::USE_SHADERS) {
+        target.draw(m_circleShape, m_shader.shader.get());
+    } else {
+        target.draw(m_circleShape);
+    }
+
+    // Outline
+    m_outlineShape.setPosition(mine.getPosition());
+    m_outlineShape.setRadius(mine.getRadius());
+    m_outlineShape.setOutlineThickness(1.f);
+    m_outlineShape.setOutlineColor(RenderingDef::RESOURCE_COLORS[mine.getResourceType()]);
+
+    target.draw(m_outlineShape);
 }

--- a/src/client/rendering/DrawableMine.hpp
+++ b/src/client/rendering/DrawableMine.hpp
@@ -18,9 +18,11 @@ class DrawableMine : public DrawableCircle {
     DrawableMine(const DrawableMine& temp_obj) = delete;
     DrawableMine& operator=(const DrawableMine& temp_obj) = delete;
 
-    void draw(sf::RenderTarget& target, Mine& mine, uint32_t resource_count);
+    void draw(sf::RenderTarget& target, Mine& mine, uint32_t resource_count,
+              const std::array<uint32_t, RESOURCE_TYPE_COUNT>& resource_counts);
 
   private:
+    float m_resourceCounts[RESOURCE_TYPE_COUNT] = {0}; // Used to pass resource counts to shader
 };
 
 #endif /* DrawableMine_hpp */

--- a/src/client/rendering/GameObjectRenderer.cpp
+++ b/src/client/rendering/GameObjectRenderer.cpp
@@ -54,8 +54,8 @@ void GameObjectRenderer::drawMines(sf::RenderTarget& target) {
         auto& drawable_mine = m_drawableMines[i];
         Mine& mine = m_mineController.getMine(mine_id);
 
-        drawable_mine->draw(target, mine,
-                            m_resourceController.get(mine_id, mine.getResourceType()));
+        drawable_mine->draw(target, mine, m_resourceController.get(mine_id, mine.getResourceType()),
+                            m_resourceController.get(mine_id));
     }
 }
 

--- a/src/client/rendering/RenderingDef.hpp
+++ b/src/client/rendering/RenderingDef.hpp
@@ -19,7 +19,7 @@ namespace RenderingDef {
 
     /* Group */
     const sf::Color DEFAULT_GROUP_COLOR(sf::Color::Transparent);
-    const sf::Color DEFAULT_GROUP_OUTLINE_COLOR(sf::Color::Transparent);
+    const sf::Color DEFAULT_GROUP_OUTLINE_COLOR(sf::Color::White);
     const sf::Color JOINABLE_COLOR(sf::Color::Green);
     const sf::Color UNGROUP_COLOR(sf::Color::Blue);
     const sf::Color PLAYER_ID_TEXT_COLOR(sf::Color::Black);

--- a/src/common/objects/Mine.hpp
+++ b/src/common/objects/Mine.hpp
@@ -8,6 +8,7 @@
 #include <SFML/Network.hpp>
 
 #include "../systems/ResourceController.hpp"
+#include "../util/game_settings.hpp"
 #include "CircleGameObject.hpp"
 
 struct MineUpdate {
@@ -37,12 +38,17 @@ class Mine : public CircleGameObject {
         return m_resourceType;
     }
 
+    uint32_t getResourceCapacity() const {
+        return m_resourceCapacity;
+    }
+
     MineUpdate getUpdate();
     void applyUpdate(MineUpdate mu);
 
   private:
     ResourceType m_resourceType;
     uint32_t m_resourceCount = 0;
+    uint32_t m_resourceCapacity = MINE_RESOURCE_COUNT;
 };
 
 #endif /* Mine_hpp */

--- a/src/common/systems/MineController.cpp
+++ b/src/common/systems/MineController.cpp
@@ -32,7 +32,8 @@ uint32_t MineController::createMine(sf::Vector2f center_position) {
     uint32_t new_mine_id = new_mine.getId();
     new_mine.setCenterPosition(center_position);
     new_mine.setActive(true);
-    m_resourceController.add(new_mine_id, new_mine.getResourceType(), MINE_RESOURCE_COUNT);
+    m_resourceController.add(new_mine_id, new_mine.getResourceType(),
+                             new_mine.getResourceCapacity());
     return new_mine_id;
 }
 


### PR DESCRIPTION

**Description**

Show mine resource count with voronoi_counts shader.

![show_mine_resource_count](https://user-images.githubusercontent.com/3184499/71480890-fdc19280-2814-11ea-9098-40dac95d380a.gif)

**Fixes**

Fixes #132 

**Commits**

[3f10515] Show mine resource count
- Mines now use the same shaders as groups to show how much resource
they contain
- Modify voronoi_counts shader to render transparent instead of white
for default cells
- Add outline to mine

