### PR TITLE
Level loading system

### DIFF
--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -12,13 +12,20 @@ int main(int argc, char** argv) {
     try {
         cxxopts::Options options("Ungroup Client",
                                  "The client for Ungroup - a game about temporary allainces.");
-        options.add_options()("x,headless", "Runs game without updating window.")(
-            "b,bot", "Runs game using a bot.")(
+        options.add_options()("h,help", "Displays options.")(
+            "x,headless", "Runs game without updating window.")("b,bot", "Runs game using a bot.")(
             "a,server-ip", "The server's IP address in CIDR notation (ex. 127.0.0.1)",
             cxxopts::value<std::string>())(
             "s,strategy", "Runs game using specified strategy. Options are Random, NearestGreedy.",
             cxxopts::value<int>());
         auto result = options.parse(argc, argv);
+
+        bool is_help = result["help"].as<bool>();
+        if (is_help) {
+            std::cout << options.help() << std::endl;
+            return EXIT_SUCCESS;
+        }
+
         bool is_headless = result["headless"].as<bool>();
         bool is_bot = result["bot"].as<bool>();
 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -1,11 +1,12 @@
+#include <cxxopts.hpp>
 #include <iostream>
+
+#include <SFML/Graphics.hpp>
 
 #include "../common/bots/Bot.hpp"
 #include "../common/util/game_def.hpp"
 #include "../common/util/game_settings.hpp"
 #include "systems/ClientGameController.hpp"
-#include <SFML/Graphics.hpp>
-#include <cxxopts.hpp>
 
 int main(int argc, char** argv) {
     try {

--- a/src/client/rendering/RenderingDef.hpp
+++ b/src/client/rendering/RenderingDef.hpp
@@ -17,12 +17,15 @@ namespace RenderingDef {
         std::shared_ptr<sf::Shader> shader = nullptr;
     };
 
+    /* Debug */
+    const sf::Color DEBUG_TEXT_COLOR(sf::Color::Green);
+
     /* Group */
     const sf::Color DEFAULT_GROUP_COLOR(sf::Color::Transparent);
     const sf::Color DEFAULT_GROUP_OUTLINE_COLOR(sf::Color::White);
     const sf::Color JOINABLE_COLOR(sf::Color::Green);
     const sf::Color UNGROUP_COLOR(sf::Color::Blue);
-    const sf::Color PLAYER_ID_TEXT_COLOR(sf::Color::Black);
+    const sf::Color PLAYER_ID_TEXT_COLOR(DEBUG_TEXT_COLOR);
     const float PLAYER_ID_TEXT_SIZE(50.f);
 
     /* Direction lines and arrows */
@@ -73,7 +76,7 @@ namespace RenderingDef {
     /* UI */
     const sf::Color RESOURCE_UI_TEXT_COLOR(sf::Color::White);
     const float RESOURCE_UI_TEXT_SIZE(60.f);
-    const sf::Color DEBUG_UI_TEXT_COLOR(sf::Color::Green);
+    const sf::Color DEBUG_UI_TEXT_COLOR(DEBUG_TEXT_COLOR);
     const float DEBUG_UI_TEXT_SIZE(50.f);
 
 }; // namespace RenderingDef

--- a/src/client/rendering/RenderingDef.hpp
+++ b/src/client/rendering/RenderingDef.hpp
@@ -59,7 +59,7 @@ namespace RenderingDef {
                          RenderingDef::RESOURCE_C_COLOR, RenderingDef::RESOURCE_D_COLOR});
 
     /* Misc */
-    const sf::Color BACKGROUND_COLOR(10, 10, 10);
+    const sf::Color BACKGROUND_COLOR(34, 32, 52);
     const sf::Color OUT_OF_BOUNDS_COLOR(100, 100, 100);
     const size_t GAME_BOUNDS_CIRCLE_SIDES = 80;
     const float BACKGROUND_TEXTURE_1_ALPHA = 255 * .8;

--- a/src/client/systems/ClientGameController.cpp
+++ b/src/client/systems/ClientGameController.cpp
@@ -10,8 +10,10 @@
 #include "../../common/util/game_settings.hpp"
 #include "ClientGameController.hpp"
 
-ClientGameController::ClientGameController(bool is_headless, bool is_bot, BotStrategy strategy) :
-    m_headless(is_headless), m_isBot(is_bot), m_strategy(strategy), GameController(),
+ClientGameController::ClientGameController(bool is_headless, bool is_bot, BotStrategy strategy,
+                                           LevelKey level_key) :
+    m_headless(is_headless),
+    m_isBot(is_bot), m_strategy(strategy), GameController(level_key),
     m_window(sf::VideoMode(WINDOW_RESOLUTION.x, WINDOW_RESOLUTION.y), "Ungroup", sf::Style::Close),
     m_networkingClient(new NetworkingClient()), m_inputController(new InputController(INPUT_KEYS)),
     m_renderingController(

--- a/src/client/systems/ClientGameController.hpp
+++ b/src/client/systems/ClientGameController.hpp
@@ -20,7 +20,8 @@ class ClientGameController : public GameController {
 
   public:
     explicit ClientGameController(bool is_headless = false, bool is_bot = false,
-                                  BotStrategy strategy = BotStrategy::Random);
+                                  BotStrategy strategy = BotStrategy::Random,
+                                  LevelKey level_key = LevelKey::empty);
     ~ClientGameController();
 
     void start() override;

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(common-lib
     systems/GameObjectController.cpp
     systems/GameController.cpp
     systems/ResourceController.cpp
+    systems/LevelController.cpp
     factories/IdFactory.cpp
     bots/Bot.cpp
 )

--- a/src/common/systems/GameController.cpp
+++ b/src/common/systems/GameController.cpp
@@ -14,10 +14,10 @@
 #include "../util/game_settings.hpp"
 #include "GameObjectStore.hpp"
 
-GameController::GameController() :
+GameController::GameController(LevelKey level_key) :
     m_physicsController(new PhysicsController()),
     m_gameObjectStore(new GameObjectStore(*m_physicsController)),
-    m_gameObjectController(new GameObjectController(*m_gameObjectStore)),
+    m_gameObjectController(new GameObjectController(*m_gameObjectStore, level_key)),
     m_gameStateCore({.tick = 0, .status = GameStatus::not_started, .winner_player_id = 0}) {
 }
 

--- a/src/common/systems/GameController.hpp
+++ b/src/common/systems/GameController.hpp
@@ -21,7 +21,7 @@ class GameController {
     // Game state is stepped at least every <MIN_TIME_STEP> milliseconds.
     sf::Int32 MIN_TIME_STEP = (sf::Int32)((1 / 60.) * 1000.);
 
-    explicit GameController();
+    explicit GameController(LevelKey level_key);
     ~GameController();
     GameController(const GameController& temp_obj) = delete;
     GameController& operator=(const GameController& temp_obj) = delete;

--- a/src/common/systems/GameObjectController.cpp
+++ b/src/common/systems/GameObjectController.cpp
@@ -8,12 +8,14 @@
 #include "../util/game_def.hpp"
 #include "../util/game_settings.hpp"
 
-GameObjectController::GameObjectController(GameObjectStore& gos) :
+GameObjectController::GameObjectController(GameObjectStore& gos, LevelKey level_key) :
     m_gameObjectStore(gos), m_playerController(m_gameObjectStore.getPlayers()),
     m_groupController(m_gameObjectStore.getGroups(), m_gameObjectStore.getPlayers(),
                       m_resourceController),
-    m_mineController(m_gameObjectStore.getMines(), m_resourceController) {
+    m_mineController(m_gameObjectStore.getMines(), m_resourceController),
+    m_levelController(m_groupController, m_mineController) {
     addEventListeners();
+    m_levelController.loadLevel(level_key);
 }
 
 GameObjectController::~GameObjectController(){};

--- a/src/common/systems/GameObjectController.hpp
+++ b/src/common/systems/GameObjectController.hpp
@@ -10,13 +10,14 @@
 #include "../util/game_def.hpp"
 #include "GameObjectStore.hpp"
 #include "GroupController.hpp"
+#include "LevelController.hpp"
 #include "MineController.hpp"
 #include "PlayerController.hpp"
 #include "ResourceController.hpp"
 
 class GameObjectController {
   public:
-    GameObjectController(GameObjectStore& gos);
+    GameObjectController(GameObjectStore& gos, LevelKey level_key);
     ~GameObjectController();
 
     void update(const InputDef::PlayerInputs& pi);
@@ -47,6 +48,7 @@ class GameObjectController {
     PlayerController m_playerController;
     GroupController m_groupController;
     MineController m_mineController;
+    LevelController m_levelController;
 
     Bot m_bot;
 };

--- a/src/common/systems/GameObjectStore.cpp
+++ b/src/common/systems/GameObjectStore.cpp
@@ -21,7 +21,7 @@ GameObjectStore::GameObjectStore(PhysicsController& pc) : m_physicsController(pc
     for (int i = 0; i < MAX_PLAYER_COUNT; i++) {
         uint32_t new_group_id = IdFactory::getInstance().getNextId(GameObjectType::group);
         m_groups.push_back(
-            std::shared_ptr<Group>(new Group(new_group_id, GAME_CENTER, m_physicsController)));
+            std::shared_ptr<Group>(new Group(new_group_id, {0.f, 0.f}, m_physicsController)));
     }
 
     // Initialize Mines

--- a/src/common/systems/LevelController.cpp
+++ b/src/common/systems/LevelController.cpp
@@ -1,0 +1,29 @@
+#include "LevelController.hpp"
+
+#include "../physics/VectorUtil.hpp"
+#include "../util/game_settings.hpp"
+
+LevelController::LevelController(GroupController& gc, MineController& mc) :
+    m_groupController(gc), m_mineController(mc) {
+}
+
+void LevelController::loadLevel(LevelKey level_key) {
+    if (m_levelLoaders.count(level_key) == 0) {
+        throw std::runtime_error("Level with used key doesn't exist");
+    }
+    (m_levelLoaders[level_key])();
+}
+
+void LevelController::loadLevelEmpty() {
+}
+
+void LevelController::loadLevelMineRing() {
+    // Create mines in a ring around the center of the game
+    for (int i = 0; i < MAX_MINE_COUNT; i++) {
+        float radius = GAME_BOUNDS_RADIUS * 0.8f;
+        float angle = i * 360.f / MAX_MINE_COUNT;
+        sf::Vector2f direction = VectorUtil::direction(angle);
+        sf::Vector2f mine_center_position = GAME_CENTER + direction * radius;
+        m_mineController.createMine(mine_center_position);
+    }
+}

--- a/src/common/systems/LevelController.cpp
+++ b/src/common/systems/LevelController.cpp
@@ -26,4 +26,9 @@ void LevelController::loadLevelMineRing() {
         sf::Vector2f mine_center_position = GAME_CENTER + direction * radius;
         m_mineController.createMine(mine_center_position);
     }
+
+    // Set groups at the center of the game
+    for (uint32_t group_id : m_groupController.getGroupIds()) {
+        m_groupController.getGroup(group_id).setPosition(GAME_CENTER);
+    }
 }

--- a/src/common/systems/LevelController.hpp
+++ b/src/common/systems/LevelController.hpp
@@ -1,0 +1,42 @@
+/**
+ * Loads levels for game. A level being an initial layout of game objects.
+ * To define a new level, create a LevelKey a LoadLevelX method and add them to the level loaders
+ * map.
+ */
+
+#ifndef LevelController_hpp
+#define LevelController_hpp
+
+#include <functional>
+
+#include "GroupController.hpp"
+#include "MineController.hpp"
+
+enum LevelKey { mine_ring, empty };
+
+class LevelController {
+  public:
+    explicit LevelController(GroupController& gc, MineController& mc);
+    ~LevelController(){};
+    LevelController(const LevelController& temp_obj) = delete;
+    LevelController& operator=(const LevelController& temp_obj) = delete;
+
+    /**
+     * Runs the loadLevel method corresponding to to the level_key
+     */
+    void loadLevel(LevelKey level_key);
+
+  private:
+    /* Level loading methods */
+    void loadLevelMineRing();
+    void loadLevelEmpty();
+
+    std::map<LevelKey, std::function<void()>> m_levelLoaders = {
+        {LevelKey::mine_ring, std::bind(&LevelController::loadLevelMineRing, this)},
+        {LevelKey::empty, std::bind(&LevelController::loadLevelEmpty, this)}};
+
+    GroupController& m_groupController;
+    MineController& m_mineController;
+};
+
+#endif /* LevelController_hpp */

--- a/src/common/systems/MineController.cpp
+++ b/src/common/systems/MineController.cpp
@@ -9,14 +9,6 @@
 
 MineController::MineController(std::vector<std::shared_ptr<Mine>>& mines, ResourceController& rc) :
     m_mines(mines), m_resourceController(rc) {
-    // Create mines in a ring around the center of the game
-    for (int i = 0; i < MAX_MINE_COUNT; i++) {
-        float radius = GAME_BOUNDS_RADIUS * 0.8f;
-        float angle = i * 360.f / MAX_MINE_COUNT;
-        sf::Vector2f direction = VectorUtil::direction(angle);
-        sf::Vector2f mine_center_position = GAME_CENTER + direction * radius;
-        createMine(mine_center_position);
-    }
 }
 
 MineController::~MineController() {

--- a/src/common/util/game_settings.hpp
+++ b/src/common/util/game_settings.hpp
@@ -30,7 +30,6 @@ const float GAME_SCALE = 5.f;
 const sf::Vector2f GAME_SCALING_FACTOR(GAME_SCALE* GAME_SIZE.x / WINDOW_RESOLUTION.x,
                                        GAME_SCALE* GAME_SIZE.y / WINDOW_RESOLUTION.y);
 
-const bool USE_SHADER = true;
 const bool SHOW_DIRECTION_ARROWS = false;
 const bool SHOW_DIRECTION_LINES = true;
 const bool SHOW_PLAYER_IDS = true;

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -7,4 +7,4 @@ add_library(server-lib
     systems/ServerGameController.cpp
 )
 
-target_link_libraries(ug-server PRIVATE server-lib common-lib)
+target_link_libraries(ug-server PRIVATE server-lib common-lib cxxopts)

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -1,9 +1,29 @@
-#include "../common/util/game_settings.hpp"
-#include "systems/ServerGameController.hpp"
+#include <cxxopts.hpp>
 #include <iostream>
 
-int main(int, char const**) {
-    ServerGameController server_game_controller;
-    server_game_controller.start();
-    return EXIT_SUCCESS;
+#include "../common/systems/LevelController.hpp"
+#include "../common/util/game_settings.hpp"
+#include "systems/ServerGameController.hpp"
+
+int main(int argc, char** argv) {
+    try {
+        cxxopts::Options options("Ungroup Server",
+                                 "The server for Ungroup - a game about temporary allainces.");
+        options.add_options()("l,level", "Loads a level. Options are mine_ring, empty.",
+                              cxxopts::value<int>());
+        auto result = options.parse(argc, argv);
+
+        bool level_opt_present = result.count("level");
+        LevelKey level = LevelKey::mine_ring;
+        if (level_opt_present) {
+            level = static_cast<LevelKey>(result["level"].as<int>());
+        }
+
+        ServerGameController server_game_controller(level);
+        server_game_controller.start();
+        return EXIT_SUCCESS;
+    } catch (const cxxopts::OptionException& e) {
+        std::cerr << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
 }

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -9,9 +9,15 @@ int main(int argc, char** argv) {
     try {
         cxxopts::Options options("Ungroup Server",
                                  "The server for Ungroup - a game about temporary allainces.");
-        options.add_options()("l,level", "Loads a level. Options are mine_ring, empty.",
-                              cxxopts::value<int>());
+        options.add_options()("h,help", "Displays options.")(
+            "l,level", "Loads a level. Options are mine_ring, empty.", cxxopts::value<int>());
         auto result = options.parse(argc, argv);
+
+        bool is_help = result["help"].as<bool>();
+        if (is_help) {
+            std::cout << options.help() << std::endl;
+            return EXIT_SUCCESS;
+        }
 
         bool level_opt_present = result.count("level");
         LevelKey level = LevelKey::mine_ring;

--- a/src/server/systems/ServerGameController.cpp
+++ b/src/server/systems/ServerGameController.cpp
@@ -1,7 +1,7 @@
 #include "ServerGameController.hpp"
 
-ServerGameController::ServerGameController() :
-    GameController(), m_networkingServer(new NetworkingServer()) {
+ServerGameController::ServerGameController(LevelKey level_key) :
+    GameController(level_key), m_networkingServer(new NetworkingServer()) {
 }
 
 ServerGameController::~ServerGameController() {

--- a/src/server/systems/ServerGameController.hpp
+++ b/src/server/systems/ServerGameController.hpp
@@ -8,11 +8,12 @@
 
 #include "../../common/events/Event.hpp"
 #include "../../common/systems/GameController.hpp"
+#include "../../common/systems/LevelController.hpp"
 #include "NetworkingServer.hpp"
 
 class ServerGameController : public GameController {
   public:
-    explicit ServerGameController();
+    explicit ServerGameController(LevelKey level_key = LevelKey::mine_ring);
     ~ServerGameController();
 
     void start() override;


### PR DESCRIPTION
**Description**

Allows defining levels and loading them via command line arguments.
*e.g.*
```
./build/src/server/ug-server --level 1
```

Also adds a `--help` cli:
```
➜ ./build/src/client/ug-client -h
The client for Ungroup - a game about temporary allainces.
Usage:
  Ungroup Client [OPTION...]

  -h, --help           Displays options.
  -x, --headless       Runs game without updating window.
  -b, --bot            Runs game using a bot.
  -a, --server-ip arg  The server's IP address in CIDR notation (ex.
                       127.0.0.1)
  -s, --strategy arg   Runs game using specified strategy. Options are
                       Random, NearestGreedy.

```

```
➜ ./build/src/server/ug-server --help
The server for Ungroup - a game about temporary allainces.
Usage:
  Ungroup Server [OPTION...]

  -h, --help       Displays options.
  -l, --level arg  Loads a level. Options are mine_ring, empty.
```

**Fixes**

Fixes #146 