### PR TITLE
Connecting and winner screen visuals

### DIFF
--- a/src/client/rendering/RenderingController.cpp
+++ b/src/client/rendering/RenderingController.cpp
@@ -27,9 +27,13 @@ RenderingController::RenderingController(sf::RenderWindow& window, GameObjectCon
     m_windowView = sf::View(window_size / 2.f, window_size);
     m_playerView = sf::View({}, sf::Vector2f(m_window.getSize()));
 
+    // Connecting text parameters
+    m_connectingText.setFont(*m_resourceStore.getFont(RenderingDef::FontKey::monogram));
+    m_connectingText.setCharacterSize(100.f);
+    m_connectingText.setFillColor(sf::Color::White);
+
     // Winner text parameters
     m_winnerText.setFont(*m_resourceStore.getFont(RenderingDef::FontKey::monogram));
-    m_winnerText.setString("WINNER: NO DATA");
     m_winnerText.setCharacterSize(100.f);
     m_winnerText.setFillColor(sf::Color::White);
 }
@@ -71,7 +75,15 @@ void RenderingController::draw() {
 }
 
 void RenderingController::drawNotStarted() {
-    m_window.clear(sf::Color::Blue);
+    m_window.clear(RenderingDef::CONNECTING_SCREEN_COLOR);
+
+    m_connectingText.setString("Connecting...");
+    sf::FloatRect textRect = m_connectingText.getLocalBounds();
+    m_connectingText.setOrigin(textRect.left + textRect.width / 2.0f,
+                               textRect.top + textRect.height / 2.0f);
+    m_connectingText.setPosition(sf::Vector2f(m_window.getSize()) / 2.f);
+    m_window.draw(m_connectingText);
+
     m_window.display();
 }
 
@@ -97,12 +109,14 @@ void RenderingController::drawPlaying() {
 }
 
 void RenderingController::drawGameOver() {
-    m_window.clear(sf::Color::Red);
-    m_winnerText.setString("WINNER: " + std::to_string(m_uiData.winner_player_id));
+    m_window.clear(RenderingDef::WINNER_SCREEN_COLOR);
+
+    m_winnerText.setString("Winner: " + std::to_string(m_uiData.winner_player_id));
     sf::FloatRect textRect = m_winnerText.getLocalBounds();
     m_winnerText.setOrigin(textRect.left + textRect.width / 2.0f,
                            textRect.top + textRect.height / 2.0f);
     m_winnerText.setPosition(sf::Vector2f(m_window.getSize()) / 2.f);
     m_window.draw(m_winnerText);
+
     m_window.display();
 }

--- a/src/client/rendering/RenderingController.hpp
+++ b/src/client/rendering/RenderingController.hpp
@@ -44,6 +44,7 @@ class RenderingController {
     sf::Vector2f m_playerPosition;
 
     sf::Text m_winnerText;
+    sf::Text m_connectingText;
 
     GameObjectController& m_gameObjectController;
     ResourceStore m_resourceStore;

--- a/src/client/rendering/RenderingDef.hpp
+++ b/src/client/rendering/RenderingDef.hpp
@@ -79,6 +79,10 @@ namespace RenderingDef {
     const sf::Color DEBUG_UI_TEXT_COLOR(DEBUG_TEXT_COLOR);
     const float DEBUG_UI_TEXT_SIZE(50.f);
 
+    /* Screens */
+    const sf::Color CONNECTING_SCREEN_COLOR(RESOURCE_A_COLOR);
+    const sf::Color WINNER_SCREEN_COLOR(RESOURCE_D_COLOR);
+
 }; // namespace RenderingDef
 
 #endif /* RenderingDef_hpp */


### PR DESCRIPTION
**Description**

*Connecting screen*
<img width="580" alt="Screen Shot 2020-01-05 at 3 04 26 PM" src="https://user-images.githubusercontent.com/3184499/71785384-d6b15080-2fcc-11ea-8317-30230e22c084.png">

*Winner screen*
<img width="555" alt="Screen Shot 2020-01-05 at 3 05 06 PM" src="https://user-images.githubusercontent.com/3184499/71785385-d87b1400-2fcc-11ea-85d7-a62966c2e352.png">

**FIxes**

Nothing