### PR TITLE
Improve server networking

### DIFF
--- a/src/common/util/game_settings.hpp
+++ b/src/common/util/game_settings.hpp
@@ -72,6 +72,7 @@ const std::chrono::milliseconds CLIENT_UNRELIABLE_RECV_SLEEP(SERVER_BROADCAST_GA
 
 /* Networking */
 static const unsigned short SERVER_TCP_PORT = 4844;
+static const unsigned short SERVER_UDP_PORT = 4845;
 static const std::string LOCALHOST_IP = "127.0.0.1";
 
 #endif /* game_settings_hpp */


### PR DESCRIPTION
**Description**

* increase TCP timeout to 300 ms for more resiliency
* add support for operating with clients behind Symmetric NATs
** these NATs will rewrite the source port of UDP traffic from the
client which meant the server using the UDP port it gets from the client
via the intial registration over the TCP connection (registerClient),
wasn't working. The NAT would just drop the traffic since the
destination port didn't match the source port it had used for sending
out the client's nat_punch.
* set server UDP port to a fixed port: 4845. Simplifies firewall rule
  configuration.

**Fixes**

Fixes #164 
