### PR TITLE
Imporve performance of TemporalMetric

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -26,4 +26,4 @@ add_library(client-lib
     resources/ResourceStore.cpp
 )
 
-target_link_libraries(ug-client PRIVATE client-lib common-lib cxxopts)
+target_link_libraries(ug-client PRIVATE client-lib common-lib cxxopts ${GPERFTOOLS_PROFILER})

--- a/src/common/metrics/TemporalMetric.cpp
+++ b/src/common/metrics/TemporalMetric.cpp
@@ -1,13 +1,14 @@
 #include "TemporalMetric.hpp"
 
+#include <iostream>
 #include <numeric>
 
 TemporalMetric::TemporalMetric(size_t size, sf::Time time_granularity) :
-    m_counts(size), m_timeGranularity(time_granularity) {
+    m_countSlots(size), m_timeGranularity(time_granularity) {
 }
 
 float TemporalMetric::getRate(sf::Time interval) {
-    sf::Time total_time = static_cast<float>(m_counts.size()) * m_timeGranularity;
+    sf::Time total_time = static_cast<float>(m_countSlots.size()) * m_timeGranularity;
     if (total_time.asSeconds() == 0 || interval.asSeconds() == 0) {
         return 0;
     }
@@ -40,16 +41,20 @@ void TemporalMetric::pushCount(int n) {
 void TemporalMetric::update() {
     if (m_clock.getElapsedTime() > m_timeGranularity) {
         m_clock.restart();
-        m_counts.push_back(m_currentCounts);
-        m_currentCounts.clear();
+        stepSlot();
     }
+}
+
+void TemporalMetric::stepSlot() {
+    m_countSlots.push_back(m_currentCounts);
+    m_currentCounts.clear();
 }
 
 std::pair<size_t, int> TemporalMetric::accumulateCounts() {
     size_t total_count = 0;
     int total_sum = 0;
-    for (auto& counts : m_counts) {
-        for (auto& count : counts) {
+    for (auto& count_slot : m_countSlots) {
+        for (auto& count : count_slot) {
             total_count += 1;
             total_sum += count;
         }

--- a/src/common/metrics/TemporalMetric.cpp
+++ b/src/common/metrics/TemporalMetric.cpp
@@ -11,20 +11,22 @@ float TemporalMetric::getRate(sf::Time interval) {
     if (total_time.asSeconds() == 0 || interval.asSeconds() == 0) {
         return 0;
     }
-    std::vector<int> all_counts = getAllCounts();
-    int total_count = std::accumulate(all_counts.begin(), all_counts.end(), 0);
-    float count_per_second = static_cast<float>(total_count) / total_time.asSeconds();
+    size_t total_count;
+    int total_sum;
+    std::tie(total_count, total_sum) = accumulateCounts();
+    float count_per_second = static_cast<float>(total_sum) / total_time.asSeconds();
     float rate = count_per_second / interval.asSeconds();
     return rate;
 }
 
 float TemporalMetric::getAverage() {
-    std::vector<int> all_counts = getAllCounts();
-    int total_count = std::accumulate(all_counts.begin(), all_counts.end(), 0);
-    if (all_counts.size() == 0) {
+    size_t total_count;
+    int total_sum;
+    std::tie(total_count, total_sum) = accumulateCounts();
+    if (total_count == 0) {
         return 0;
     }
-    return static_cast<float>(total_count) / all_counts.size();
+    return static_cast<float>(total_sum) / total_count;
 }
 
 void TemporalMetric::pushCount() {
@@ -43,10 +45,14 @@ void TemporalMetric::update() {
     }
 }
 
-std::vector<int> TemporalMetric::getAllCounts() {
-    return std::accumulate(m_counts.begin(), m_counts.end(), std::vector<int>(),
-                           [](std::vector<int> a, std::vector<int> b) {
-                               a.insert(a.end(), b.begin(), b.end());
-                               return a;
-                           });
+std::pair<size_t, int> TemporalMetric::accumulateCounts() {
+    size_t total_count = 0;
+    int total_sum = 0;
+    for (auto& counts : m_counts) {
+        for (auto& count : counts) {
+            total_count += 1;
+            total_sum += count;
+        }
+    }
+    return std::make_pair(total_count, total_sum);
 }

--- a/src/common/metrics/TemporalMetric.hpp
+++ b/src/common/metrics/TemporalMetric.hpp
@@ -2,7 +2,7 @@
  * Keeps track of a metric temporally in order to produce it's rate over an interval of time.
  *
  * Counts are stored in a specified number of slots each representing an equal amount of time.
- * Counts are accumilated in a slot until the interval of time has passed, at which point counts
+ * Counts are accumulated in a slot until the interval of time has passed, at which point counts
  * start accumilating in a new slot. There are a limited number of slots and each time a new slot is
  * used, the oldest is discarded.
  *
@@ -56,9 +56,9 @@ class TemporalMetric {
 
   private:
     /**
-     * Flattens m_counts, which is a circular buffer of vectors, into a single vector.
+     * Returns the count and sum of all the counts.
      */
-    std::vector<int> getAllCounts();
+    std::pair<size_t, int> accumulateCounts();
 
     sf::Clock m_clock;
     boost::circular_buffer<std::vector<int>> m_counts;

--- a/src/common/metrics/TemporalMetric.hpp
+++ b/src/common/metrics/TemporalMetric.hpp
@@ -29,7 +29,7 @@ class TemporalMetric {
     TemporalMetric& operator=(const TemporalMetric& temp_obj) = delete;
 
     /**
-     * Updates the slot currently accumilating the metric if need be.
+     * If enough time has elapsed then updates slot currently accumulating counts.
      * Should be called as often as possible.
      */
     void update();
@@ -54,6 +54,11 @@ class TemporalMetric {
      */
     float getAverage();
 
+    /**
+     * Updates the slot currently accumilating the metric.
+     */
+    void stepSlot();
+
   private:
     /**
      * Returns the count and sum of all the counts.
@@ -61,7 +66,7 @@ class TemporalMetric {
     std::pair<size_t, int> accumulateCounts();
 
     sf::Clock m_clock;
-    boost::circular_buffer<std::vector<int>> m_counts;
+    boost::circular_buffer<std::vector<int>> m_countSlots;
     sf::Time m_timeGranularity;
     std::vector<int> m_currentCounts;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(ug-test
     client/rendering/tests-AnimatedSprite.cpp
     client/rendering/tests-AnimationController.cpp
     common/systems/tests-ResourceController.cpp
+    common/metrics/tests-TemporalMetric.cpp
 )
 
 target_link_libraries(ug-test PRIVATE server-lib common-lib client-lib catch)

--- a/tests/common/metrics/tests-TemporalMetric.cpp
+++ b/tests/common/metrics/tests-TemporalMetric.cpp
@@ -1,0 +1,29 @@
+#include <catch.hpp>
+
+#include "../../../src/common/metrics/TemporalMetric.hpp"
+
+TEST_CASE("Average", "[common][metrics][TemporalMetric][getAverage]") {
+    TemporalMetric temporal_metric(10, sf::seconds(1));
+    temporal_metric.pushCount(1);
+    temporal_metric.pushCount(5);
+    temporal_metric.stepSlot();
+    temporal_metric.pushCount(-1);
+    temporal_metric.pushCount(3);
+    temporal_metric.stepSlot();
+
+    REQUIRE(temporal_metric.getAverage() == 2);
+}
+
+TEST_CASE("Rate", "[common][metrics][TemporalMetric][getRate]") {
+    TemporalMetric temporal_metric(10, sf::seconds(1));
+    temporal_metric.pushCount(1);
+    temporal_metric.pushCount(5);
+    temporal_metric.stepSlot();
+    temporal_metric.pushCount(-1);
+    temporal_metric.pushCount(3);
+    temporal_metric.stepSlot();
+
+    REQUIRE(temporal_metric.getRate(sf::seconds(1)) == 4);
+    REQUIRE(temporal_metric.getRate(sf::seconds(2)) == 2);
+    REQUIRE(temporal_metric.getRate(sf::seconds(0.5)) == 8);
+}


### PR DESCRIPTION

**Description**

- Iterate over counts to accumulate instead of creating a flattened list

Client now runs at 30% cpu on my mac. Before it was 99%...

**Fixes**

Fixes #169 
