### PR TITLE
Remove group outline

### DIFF
--- a/resources/shaders/voronoi_counts.frag
+++ b/resources/shaders/voronoi_counts.frag
@@ -42,7 +42,7 @@ void main() {
     st *= u_resolution / (u_radius * 2.);
     st = fract(st);
 
-    vec4 color = vec4(1., 1., 1., .0);
+    vec4 color = vec4(1., 1., 1., 0.);
 
     // Cell colors
     vec4 color_pool[COLOR_COUNT];
@@ -58,7 +58,7 @@ void main() {
 
     // Set all to transparent
     for (int i = 0; i < u_maxResources; i++) {
-        point_color[i] = vec4(1., 1., 1., 0.);
+        point_color[i] = vec4(1., 1., 1., .0);
     }
 
     // Populate resources
@@ -80,7 +80,7 @@ void main() {
 
     float m_dist = 2.;  // minimun distance
     vec2 closest_point; // minimum position
-    vec4 closest_point_color = vec4(1., 1., 1., 0.);
+    vec4 closest_point_color = vec4(1., 1., 1., 0.05);
 
     // Iterate through the points positions
     for (int i = 0; i < CELL_COUNT; i++) {

--- a/src/client/rendering/DrawableGroup.cpp
+++ b/src/client/rendering/DrawableGroup.cpp
@@ -8,6 +8,7 @@
 DrawableGroup::DrawableGroup(ResourceStore& rs) :
     DrawableCircle(rs), m_directionArrow(), m_directionLines() {
     setShader(RenderingDef::ShaderKey::voronoi_counts);
+    m_circleShape.setFillColor(RenderingDef::DEFAULT_GROUP_COLOR);
 }
 
 void DrawableGroup::draw(sf::RenderTarget& target, Group& group, bool joinable, bool ungroup,
@@ -78,17 +79,20 @@ void DrawableGroup::drawGroup(sf::RenderTarget& target, Group& group, bool joina
     }
 
     // Outline
-    m_outlineShape.setPosition(group.getPosition());
-    m_outlineShape.setRadius(group.getRadius());
-    m_outlineShape.setOutlineThickness(1.f);
+    m_outlineShape.setRadius(group.getRadius() + RenderingDef::GROUP_OUTLINE_DISTANCE);
+    m_outlineShape.setPosition(
+        group.getCenter() - sf::Vector2f(m_outlineShape.getRadius(), m_outlineShape.getRadius()));
+    m_outlineShape.setOutlineThickness(RenderingDef::GROUP_OUTLINE_THICKNESS);
     sf::Color outline_color = RenderingDef::DEFAULT_GROUP_OUTLINE_COLOR;
 
     if (joinable) {
+        m_outlineShape.setOutlineThickness(RenderingDef::GROUP_JOINABLE_THICKNESS);
         outline_color = RenderingDef::JOINABLE_COLOR;
     }
 
     // TODO(sourenp): This was only included for debugging purposes. Remove eventually.
     if (ungroup) {
+        m_outlineShape.setOutlineThickness(RenderingDef::GROUP_JOINABLE_THICKNESS);
         outline_color = RenderingDef::UNGROUP_COLOR;
     }
 

--- a/src/client/rendering/RenderingDef.hpp
+++ b/src/client/rendering/RenderingDef.hpp
@@ -42,10 +42,13 @@ namespace RenderingDef {
     const sf::Color DEBUG_TEXT_COLOR(sf::Color::Green);
 
     /* Group */
-    const sf::Color DEFAULT_GROUP_COLOR(sf::Color::Transparent);
+    const sf::Color DEFAULT_GROUP_COLOR(255, 255, 255, 0.05 * 255);
     const sf::Color DEFAULT_GROUP_OUTLINE_COLOR(sf::Color::White);
-    const sf::Color JOINABLE_COLOR(sf::Color::Green);
-    const sf::Color UNGROUP_COLOR(sf::Color::Blue);
+    const sf::Color JOINABLE_COLOR(255, 255, 255, 1.f * 255);
+    const sf::Color UNGROUP_COLOR(0, 146, 199, 1.f * 255);
+    const float GROUP_OUTLINE_THICKNESS(0.f);
+    const float GROUP_OUTLINE_DISTANCE(1.f);
+    const float GROUP_JOINABLE_THICKNESS(1.f);
 
     // Direction Arrow
     const bool SHOW_DIRECTION_ARROWS = false;
@@ -56,7 +59,7 @@ namespace RenderingDef {
     const sf::Color DIRECTION_LINE_DEFAULT_COLOR(120, 120, 120);
     const float DIRECTION_LINE_STRIP_LENGTH(3.f);
     const float DIRECTION_LINE_COLOR_ALPHA(255 * 1.f);
-    const float DIRECTION_LINE_DISTANCE_FROM_EDGE(1.f);
+    const float DIRECTION_LINE_DISTANCE_FROM_EDGE(2.f);
 
     // Player IDs
     const sf::Color PLAYER_ID_TEXT_COLOR(DEBUG_TEXT_COLOR);


### PR DESCRIPTION
**Description**

- Group now has a shadow instead of outline. The purpose of the shadow
is for the group to be visable even when it doesn't have any resources
<img width="228" alt="Screen Shot 2020-01-26 at 7 09 34 PM" src="https://user-images.githubusercontent.com/3184499/73144077-84190080-406f-11ea-87b6-15ba8b643dfa.png">

- Group's joinable outline is now white and is slightly detached from
the group.
<img width="218" alt="Screen Shot 2020-01-26 at 7 09 48 PM" src="https://user-images.githubusercontent.com/3184499/73144071-7e231f80-406f-11ea-989f-d78fa38349e4.png">
