### PR TITLE
Update cmake to build on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,16 +5,17 @@ project(Ungroup VERSION 1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lstdc++ -pthread -static-libgcc -static-libstdc++ -static")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -g -fsanitize=address -fno-omit-frame-pointer")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+set(SFML_STATIC_LIBRARIES TRUE)
 # find sfml
-find_package(SFML 2.5 COMPONENTS audio graphics window system REQUIRED)
+find_package(SFML 2.5.1 COMPONENTS system window graphics network audio REQUIRED)
 
 # find boost
-find_package(Boost 1.65 COMPONENTS REQUIRED)
+find_package(Boost 1.55 COMPONENTS REQUIRED)
 
 add_subdirectory(src)
 add_subdirectory(extern/catch)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(Ungroup VERSION 1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -g -fsanitize=address -fno-omit-frame-pointer")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake")
@@ -16,6 +16,9 @@ if(UNGROUP_STATIC)
     set(CMAKE_FIND_FRAMEWORK LAST)
     set(SFML_STATIC_LIBRARIES TRUE)
 endif()
+
+# find threads
+find_package(Threads REQUIRED)
 
 # find sfml
 find_package(SFML 2.5.1 COMPONENTS system window graphics network audio REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,18 @@ project(Ungroup VERSION 1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lstdc++ -pthread -static-libgcc -static-libstdc++ -static")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -g -fsanitize=address -fno-omit-frame-pointer")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-set(SFML_STATIC_LIBRARIES TRUE)
+if(UNGROUP_STATIC)
+    # todo(souren|#192|2020-04-24): Unable to build with sfml statically linked on mac/linux 
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lstdc++ -static-libgcc -static-libstdc++ -static")
+    set(CMAKE_FIND_FRAMEWORK LAST)
+    set(SFML_STATIC_LIBRARIES TRUE)
+endif()
+
 # find sfml
 find_package(SFML 2.5.1 COMPONENTS system window graphics network audio REQUIRED)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Created by [@sourenp](https://github.com/SourenP) and [@copacetic](https://githu
 1. Clone this repo
 2. Install requirements
   - [SFML 2.5.1](https://www.sfml-dev.org/download/sfml/2.5.1/)
-  - [Boost 1.65](https://www.boost.org/)
+  - [Boost 1.5](https://www.boost.org/)
 3. Build:
 ```
 ./scripts/build.sh
@@ -38,6 +38,28 @@ Created by [@sourenp](https://github.com/SourenP) and [@copacetic](https://githu
 ```
 ```
 ./build/src/client/ug-client
+```
+
+### Windows
+1. Clone this repo
+2. Install requirments
+  - Mingw
+  - cmake
+3. Download dependencies
+  - [SFML 2.5.1 GCC 7.3.0 MinGW (DW2) - 32-bit](https://www.sfml-dev.org/download/sfml/2.5.1/)
+  - [Boost 1.5](https://www.boost.org/)
+3. Build:
+```
+cmake -DSFML_DIR="Path/to/SFML/lib/cmake/SFML" -DBOOST_ROOT="Path/to/Boost" -G "MinGW Makefiles" -S . -B build\
+cmake --build build
+```
+4. Run server and client in seperate terminals:
+**The server currently doesn't work on windows**
+```
+.\build\src\server\ug-server.exe
+```
+```
+ .\build\src\client\ug-client.exe
 ```
 
 *Note: if you are running from a remote server, you might need to open the tcp and udp ports on your machine*

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_subdirectory(common)
-add_subdirectory(server)
 add_subdirectory(client)
+add_subdirectory(server)

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -26,4 +26,5 @@ add_library(client-lib
     resources/ResourceStore.cpp
 )
 
-target_link_libraries(ug-client PRIVATE client-lib common-lib cxxopts)
+target_link_libraries(client-lib common-lib sfml-window sfml-graphics sfml-network sfml-system cxxopts)
+target_link_libraries(ug-client client-lib)

--- a/src/client/rendering/AnimatedSprite.cpp
+++ b/src/client/rendering/AnimatedSprite.cpp
@@ -18,8 +18,8 @@ AnimatedSprite::AnimatedSprite(sf::Texture& spritesheet_texture, sf::Vector2u sp
     m_animation(m_sprite) {
     sf::Int32 frame_count = spritesheet_size.x * spritesheet_size.y;
     sf::Vector2u texture_size = spritesheet_texture.getSize();
-    uint frame_width = texture_size.x / spritesheet_size.x;
-    uint frame_height = texture_size.y / spritesheet_size.y;
+    uint32_t frame_width = texture_size.x / spritesheet_size.x;
+    uint32_t frame_height = texture_size.y / spritesheet_size.y;
     auto size = sf::Vector2i(frame_width, frame_height);
     for (size_t j = 0; j < spritesheet_size.y; j++) {
         for (size_t i = 0; i < spritesheet_size.x; i++) {

--- a/src/client/rendering/BaseUIElement.hpp
+++ b/src/client/rendering/BaseUIElement.hpp
@@ -25,7 +25,7 @@ struct UIData {
     std::array<uint32_t, RESOURCE_TYPE_COUNT> resource_goals;
     GameStatus game_status;
     uint32_t winner_player_id;
-    uint tick;
+    uint32_t tick;
 };
 
 class BaseUIElement {

--- a/src/client/rendering/RenderingDef.hpp
+++ b/src/client/rendering/RenderingDef.hpp
@@ -8,7 +8,7 @@
 #include "../../common/util/game_settings.hpp"
 
 namespace RenderingDef {
-    const uint WINDOW_FRAME_LIMIT = 60;
+    const uint32_t WINDOW_FRAME_LIMIT = 60;
     const sf::Vector2f WINDOW_RESOLUTION(1200, 900);
     const float GAME_SCALE = 4.f;
     const sf::Vector2f GAME_SCALING_FACTOR(GAME_SCALE, GAME_SCALE);

--- a/src/client/systems/ClientGameController.cpp
+++ b/src/client/systems/ClientGameController.cpp
@@ -137,8 +137,8 @@ void ClientGameController::rewindAndReplay() {
 
     GameState game_state = m_networkingClient->getGameState();
 
-    uint client_tick = getTick();
-    uint server_tick = game_state.core.tick;
+    uint32_t client_tick = getTick();
+    uint32_t server_tick = game_state.core.tick;
     int tick_delta = client_tick - server_tick;
 
     // Rewind
@@ -155,7 +155,7 @@ void ClientGameController::rewindAndReplay() {
 
     // Loop through ticks that need to be replayed and apply client input from cache if present
     for (int i = 0; i < tick_delta; ++i) {
-        uint replay_tick = server_tick + i;
+        uint32_t replay_tick = server_tick + i;
         if (m_tickToInput.count(replay_tick) > 0) {
             InputDef::ClientInputAndTick client_input_and_tick = m_tickToInput[replay_tick];
             auto pi = InputDef::PlayerInputs(m_inputController->getPlayerInputs(

--- a/src/client/systems/ClientGameController.hpp
+++ b/src/client/systems/ClientGameController.hpp
@@ -37,8 +37,8 @@ class ClientGameController : public GameController {
 
     // Methods
 
-    uint getTick();
-    void setTick(uint tick);
+    uint32_t getTick();
+    void setTick(uint32_t tick);
 
     /**
      * Register the client via the NetworkingClient.

--- a/src/client/systems/NetworkingClient.cpp
+++ b/src/client/systems/NetworkingClient.cpp
@@ -143,8 +143,8 @@ void NetworkingClient::readRegistrationResponse() {
     if (status == sf::Socket::Done) {
         if (registration_response >> reliable_command &&
             reliable_command.command == ReliableCommandType::register_client) {
-            m_clientId_ta = static_cast<uint>(reliable_command.client_id);
-            m_tick_ta = static_cast<uint>(reliable_command.tick);
+            m_clientId_ta = static_cast<uint32_t>(reliable_command.client_id);
+            m_tick_ta = static_cast<uint32_t>(reliable_command.tick);
             registration_response >> m_serverInputUdpPort >> m_serverStateUdpPort;
             std::cout << "Registered as client " << m_clientId_ta << " at tick " << m_tick_ta
                       << std::endl
@@ -184,11 +184,11 @@ void NetworkingClient::incrementTick() {
     m_tick_ta++;
 }
 
-uint NetworkingClient::getTick() const {
+uint32_t NetworkingClient::getTick() const {
     return m_tick_ta;
 }
 
-void NetworkingClient::setTick(uint tick) {
+void NetworkingClient::setTick(uint32_t tick) {
     m_tick_ta = tick;
 }
 

--- a/src/client/systems/NetworkingClient.hpp
+++ b/src/client/systems/NetworkingClient.hpp
@@ -51,8 +51,8 @@ class NetworkingClient {
     void pushReliableInput(InputDef::ReliableInput reliable_input);
 
     void incrementTick();
-    uint getTick() const;
-    void setTick(uint tick);
+    uint32_t getTick() const;
+    void setTick(uint32_t tick);
 
   private:
     // Sockets
@@ -117,7 +117,7 @@ class NetworkingClient {
 
     // Misc
     std::atomic<int> m_clientId_ta{-1};
-    std::atomic<uint> m_tick_ta{0};
+    std::atomic<uint32_t> m_tick_ta{0};
     std::atomic<bool> m_gameStateIsFresh_ta{true};
 
     std::mutex m_gameState_lock;

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -27,4 +27,4 @@ add_library(common-lib
     models/WinCondition.cpp
 )
 
-target_link_libraries(common-lib PUBLIC sfml-system sfml-graphics sfml-network Boost::boost)
+target_link_libraries(common-lib PUBLIC sfml-graphics sfml-system Boost::boost)

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -7,4 +7,5 @@ add_library(server-lib
     systems/ServerGameController.cpp
 )
 
-target_link_libraries(ug-server PRIVATE server-lib common-lib cxxopts)
+target_link_libraries(server-lib common-lib sfml-window sfml-graphics sfml-network cxxopts)
+target_link_libraries(ug-server server-lib)

--- a/src/server/systems/NetworkingServer.cpp
+++ b/src/server/systems/NetworkingServer.cpp
@@ -175,7 +175,7 @@ void NetworkingServer::handleUnreliableCommand(sf::Socket::Status status, sf::Pa
 }
 
 void NetworkingServer::setClientUnreliableUpdate(sf::Packet packet, int client_id,
-                                                 uint client_tick) {
+                                                 uint32_t client_tick) {
     int drift = std::abs(static_cast<int>((m_tick_ta - client_tick)));
     if (drift < CMD_DRIFT_THRESHOLD) {
         sf::Uint32 player_id;

--- a/src/server/systems/NetworkingServer.hpp
+++ b/src/server/systems/NetworkingServer.hpp
@@ -99,7 +99,7 @@ class NetworkingServer {
 
     sf::Uint32 m_clientIdCounter = 0;
 
-    std::atomic<uint> m_tick_ta{0};
+    std::atomic<uint32_t> m_tick_ta{0};
 };
 
 #endif /* NetworkingServer_hpp */


### PR DESCRIPTION
**Description**

- Link dependencies to client-lib and server-lib before, in turn, linking them to their executables
  - See the path I took to discover this here: https://en.sfml-dev.org/forums/index.php?topic=27152.0
- Windows build having trouble with `uint` so I replaced them all with `uint32_t`
- Add cmake var `GUNGROUP_STATIC` to statically link sfml and gcc stuff
- Remove redundant `-std=c++11 ` from `CMAKE_CXX_FLAGS `
- Downgrade boost requirement to 1.55 because I couldn't find 1.65 on windows
- Handle `-pthreads` in a generic way with CMake's `find_package(Threads)`.

**Fixes**

Fixes #178 
