### PR TITLE
Add flags for not building client, server or tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   - make install -j
   # Cmake
   - mkdir -p ${TRAVIS_BUILD_DIR}/build && cd ${TRAVIS_BUILD_DIR}/build
-  - cmake -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/usr -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-I${TRAVIS_BUILD_DIR}/usr/include" .. && cmake -LA ..
+  - cmake -DBUILD_TESTS -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/usr -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-I${TRAVIS_BUILD_DIR}/usr/include" .. && cmake -LA ..
   - make -j VERBOSE=1
   - cd ..
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   - make install -j
   # Cmake
   - mkdir -p ${TRAVIS_BUILD_DIR}/build && cd ${TRAVIS_BUILD_DIR}/build
-  - cmake -DBUILD_TESTS -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/usr -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-I${TRAVIS_BUILD_DIR}/usr/include" .. && cmake -LA ..
+  - cmake -DBUILD_TESTS=TRUE -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/usr -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-I${TRAVIS_BUILD_DIR}/usr/include" .. && cmake -LA ..
   - make -j VERBOSE=1
   - cd ..
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,4 +30,7 @@ add_subdirectory(src)
 add_subdirectory(extern/catch)
 add_subdirectory(extern/cxxopts)
 add_subdirectory(extern/termbox)
-add_subdirectory(tests)
+
+IF(BUILD_TESTS)
+    add_subdirectory(tests)
+ENDIF()

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cd ungroup_game
 #### 3. Build
 The server currently doesn't build on windows ([#194](https://github.com/SourenP/ungroup_game/issues/194))
 ```
-cmake -DONLY_CLIENT -DSFML_DIR="Path/to/SFML/lib/cmake/SFML" -DBOOST_ROOT="Path/to/Boost" -G "MinGW Makefiles" -S . -B build\
+cmake -DONLY_CLIENT=TRUE -DSFML_DIR="Path/to/SFML/lib/cmake/SFML" -DBOOST_ROOT="Path/to/Boost" -G "MinGW Makefiles" -S . -B build\
 cmake --build build
 ```
 #### 4. Run server and client in seperate terminals
@@ -86,6 +86,8 @@ The server currently doesn't run on windows ([#194](https://github.com/SourenP/u
 ```
 
 ## Testing
+
+- Build with the flag `-GBUILD_TESTS=TRUE`
 
 To run tests, after building, run:
 ```

--- a/README.md
+++ b/README.md
@@ -22,8 +22,18 @@ Created by [@sourenp](https://github.com/SourenP) and [@copacetic](https://githu
 
 ## Build
 
-- You can statically link libraries by setting the cmake flag `-DUNGROUP_STATIC=TRUE`
 - If you are running from a remote server, you might need to open the tcp and udp ports on your machine.n
+
+### Cmake variables
+
+- Set a flag by adding the arg `-GFLAG_NAME=TRUE` to cmake
+
+| Flag  | Second Header |
+| ------------- | ------------- |
+| UNGROUP_STATIC | Statically link SFML  |
+| BUILD_TESTS  | Build tests  |
+| ONLY_SERVER  | Only build server  |
+| ONLY_CLIENT  | Only build client  |
 
 ### Unix
 #### 1. Clone this repo
@@ -62,7 +72,7 @@ cd ungroup_game
 #### 3. Build
 The server currently doesn't build on windows ([#194](https://github.com/SourenP/ungroup_game/issues/194))
 ```
-cmake -DSFML_DIR="Path/to/SFML/lib/cmake/SFML" -DBOOST_ROOT="Path/to/Boost" -G "MinGW Makefiles" -S . -B build\
+cmake -DONLY_CLIENT -DSFML_DIR="Path/to/SFML/lib/cmake/SFML" -DBOOST_ROOT="Path/to/Boost" -G "MinGW Makefiles" -S . -B build\
 cmake --build build
 ```
 #### 4. Run server and client in seperate terminals
@@ -100,7 +110,7 @@ Features:
   - Multi threaded UDP/TCP communication between server and client
   - Reliable (TCP) and Unreliable (UDP) client inputs sent to server
   - Unreliable (UDP) game state broadcasted to client
-  - Works locally and over the internet 
+  - Works locally and over the internet
 - Interpolation
   - Snapshot interpolation
 - Rendering

--- a/scripts/run_server.rb
+++ b/scripts/run_server.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+require 'socket'
+
+open_port = false
+if ARGV.length > 0 && (ARGV[0] == "--open-port")
+  open_port = true
+end
+
+# use this trick to find an open tcp port
+server = TCPServer.new('127.0.0.1', 0)
+port = server.addr[1]
+server.close
+puts "Using port: #{port}"
+
+# for dev or prod (not local), we probably want to open the port
+if open_port
+  # make sure we have closed any ports previously opened by this script
+  `firewall-cmd --reload`
+
+  # open firewall port, runs on Fedora Linux only
+  `firewall-cmd --zone=FedoraServer --add-port=#{port}/tcp`
+end
+
+# run the server on the given port
+`./build/src/server/ug-server -p #{port}`

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,10 @@
 add_subdirectory(common)
-add_subdirectory(client)
-add_subdirectory(server)
+
+IF(ONLY_CLEINT)
+    add_subdirectory(client)
+ELSEIF(ONLY_SERVER)
+    add_subdirectory(server)
+ELSE()
+    add_subdirectory(client)
+    add_subdirectory(server)
+ENDIF()

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -16,6 +16,7 @@ int main(int argc, char** argv) {
             "x,headless", "Runs game without updating window.")("b,bot", "Runs game using a bot.")(
             "a,server-ip", "The server's IP address in CIDR notation (ex. 127.0.0.1)",
             cxxopts::value<std::string>())(
+            "p,port", "The TCP port to connect to.", cxxopts::value<int>())(
             "s,strategy", "Runs game using specified strategy. Options are Random, NearestGreedy.",
             cxxopts::value<int>());
         auto result = options.parse(argc, argv);
@@ -41,7 +42,12 @@ int main(int argc, char** argv) {
             strategy = static_cast<BotStrategy>(result["strategy"].as<int>());
         }
 
-        ClientGameController client_game_controller(is_headless, is_bot, strategy, server_ip);
+        bool tcp_port_opt_present = result.count("port");
+        uint32_t tcp_port = GAME_SETTINGS.SERVER_TCP_PORT;
+        if (tcp_port_opt_present) {
+            tcp_port = result["port"].as<int>();
+        }
+        ClientGameController client_game_controller(is_headless, is_bot, strategy, server_ip, tcp_port);
         client_game_controller.start();
         return EXIT_SUCCESS;
     } catch (const cxxopts::OptionException& e) {

--- a/src/client/systems/ClientGameController.cpp
+++ b/src/client/systems/ClientGameController.cpp
@@ -11,10 +11,10 @@
 #include "ClientGameController.hpp"
 
 ClientGameController::ClientGameController(bool is_headless, bool is_bot, BotStrategy strategy,
-                                           const std::string& server_ip, LevelKey level_key) :
+                                           const std::string& server_ip, uint32_t server_tcp_port, LevelKey level_key) :
     m_headless(is_headless),
     m_isBot(is_bot), m_strategy(strategy), m_serverIP(server_ip), GameController(level_key),
-    m_networkingClient(new NetworkingClient(m_serverIP)) {
+    m_networkingClient(new NetworkingClient(m_serverIP, server_tcp_port)) {
 }
 
 ClientGameController::~ClientGameController() {

--- a/src/client/systems/ClientGameController.hpp
+++ b/src/client/systems/ClientGameController.hpp
@@ -22,6 +22,7 @@ class ClientGameController : public GameController {
     explicit ClientGameController(bool is_headless = false, bool is_bot = false,
                                   BotStrategy strategy = BotStrategy::Random,
                                   const std::string& server_ip = GAME_SETTINGS.LOCALHOST_IP,
+                                  uint32_t server_tcp_port = GAME_SETTINGS.SERVER_TCP_PORT,
                                   LevelKey level_key = LevelKey::empty);
     ~ClientGameController();
 

--- a/src/client/systems/NetworkingClient.cpp
+++ b/src/client/systems/NetworkingClient.cpp
@@ -14,11 +14,12 @@
 
 const sf::Time CLIENT_TCP_TIMEOUT = sf::milliseconds(300);
 
-NetworkingClient::NetworkingClient(const std::string& server_ip) :
+NetworkingClient::NetworkingClient(const std::string& server_ip, uint32_t server_tcp_port) :
     m_gameState_t({}), m_serverIp(server_ip) {
     std::cout << "Starting client." << std::endl;
 
-    createTcpSocket(GAME_SETTINGS.SERVER_TCP_PORT);
+    std::cout << "Server reliable port is: " << server_tcp_port << std::endl;
+    createTcpSocket(server_tcp_port);
 
     createInputUdpSocket();
     createStateUdpSocket();

--- a/src/client/systems/NetworkingClient.hpp
+++ b/src/client/systems/NetworkingClient.hpp
@@ -20,7 +20,7 @@
 class NetworkingClient {
 
   public:
-    NetworkingClient(const std::string& server_ip);
+    NetworkingClient(const std::string& server_ip, uint32_t server_tcp_port);
     ~NetworkingClient();
 
     /**

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -13,6 +13,7 @@ int main(int argc, char** argv) {
         cxxopts::Options options("Ungroup Server",
                                  "The server for Ungroup - a game about temporary allainces.");
         options.add_options()("h,help", "Displays options.")(
+            "p,port", "The TCP port to listen on.", cxxopts::value<int>())(
             "l,level", "Loads a level. Options are mine_ring, empty.", cxxopts::value<int>());
         auto result = options.parse(argc, argv);
 
@@ -28,7 +29,12 @@ int main(int argc, char** argv) {
             level = static_cast<LevelKey>(result["level"].as<int>());
         }
 
-        ServerGameController server_game_controller(level);
+        bool tcp_port_opt_present = result.count("port");
+        uint32_t tcp_port = GAME_SETTINGS.SERVER_TCP_PORT;
+        if (tcp_port_opt_present) {
+            tcp_port = result["port"].as<int>();
+        }
+        ServerGameController server_game_controller(level, tcp_port);
         server_game_controller.start();
         return EXIT_SUCCESS;
     } catch (const cxxopts::OptionException& e) {

--- a/src/server/rendering/TerminalRenderingController.cpp
+++ b/src/server/rendering/TerminalRenderingController.cpp
@@ -15,6 +15,7 @@ TerminalRenderingController::TerminalRenderingController() : m_termboxTextOutput
     m_termboxServerStatsTable.addColumn("Steps per second");
     m_termboxServerStatsTable.addColumn("Updates per second");
     m_termboxServerStatsTable.addColumn("Broadcasts per second");
+    m_termboxServerStatsTable.addColumn("Tick");
     m_termboxTextOutputArea.addTitle("Ungroup Server Output");
 }
 
@@ -56,7 +57,7 @@ void TerminalRenderingController::draw(
     std::unordered_map<uint32_t, float> player_ids_to_updates_rates,
     std::unordered_map<uint32_t, float> player_ids_to_avg_tick_drifts,
     float broadcast_game_state_rate, std::vector<PlayerUpdate> player_updates, float game_step_rate,
-    float game_update_rate) {
+    float game_update_rate, uint32_t tick) {
     // clear out internal termbox screen buffer
     tb_clear();
 
@@ -70,6 +71,7 @@ void TerminalRenderingController::draw(
     m_termboxServerStatsTable.setCell(std::to_string(game_step_rate), 1, 0);
     m_termboxServerStatsTable.setCell(std::to_string(game_update_rate), 1, 1);
     m_termboxServerStatsTable.setCell(std::to_string(broadcast_game_state_rate), 1, 2);
+    m_termboxServerStatsTable.setCell(std::to_string(tick), 1, 3);
 
     // player table will be on right half of screen
     m_termboxPlayerTable.setOrigin(tb_width() / 2, 0);

--- a/src/server/rendering/TerminalRenderingController.cpp
+++ b/src/server/rendering/TerminalRenderingController.cpp
@@ -1,6 +1,6 @@
 #include "TerminalRenderingController.hpp"
 
-TerminalRenderingController::TerminalRenderingController() : m_termboxTextOutputArea(10) {
+TerminalRenderingController::TerminalRenderingController(uint32_t tcp_port) : m_termboxTextOutputArea(10) {
     // termbox setup
     int ret = tb_init();
     if (ret) {
@@ -17,6 +17,7 @@ TerminalRenderingController::TerminalRenderingController() : m_termboxTextOutput
     m_termboxServerStatsTable.addColumn("Broadcasts per second");
     m_termboxServerStatsTable.addColumn("Tick");
     m_termboxTextOutputArea.addTitle("Ungroup Server Output");
+    m_termboxTextOutputArea.addLine("Listening on TCP Port: " + std::to_string(tcp_port));
 }
 
 void TerminalRenderingController::preUpdate() {

--- a/src/server/rendering/TerminalRenderingController.hpp
+++ b/src/server/rendering/TerminalRenderingController.hpp
@@ -21,7 +21,7 @@ class TerminalRenderingController {
     void draw(std::unordered_map<uint32_t, float> player_ids_to_updates_rates,
               std::unordered_map<uint32_t, float> player_ids_to_avg_tick_drifts,
               float broadcast_game_state_rate, std::vector<PlayerUpdate> player_updates,
-              float game_step_rate, float game_update_rate);
+              float game_step_rate, float game_update_rate, uint32_t tick);
 
     void preUpdate();
     void update();

--- a/src/server/rendering/TerminalRenderingController.hpp
+++ b/src/server/rendering/TerminalRenderingController.hpp
@@ -15,7 +15,7 @@
 
 class TerminalRenderingController {
   public:
-    TerminalRenderingController();
+    TerminalRenderingController(uint32_t tcp_port);
     ~TerminalRenderingController(){};
 
     void draw(std::unordered_map<uint32_t, float> player_ids_to_updates_rates,

--- a/src/server/systems/NetworkingServer.cpp
+++ b/src/server/systems/NetworkingServer.cpp
@@ -14,7 +14,7 @@
 
 sf::Time TCP_TIMEOUT = sf::milliseconds(300);
 
-NetworkingServer::NetworkingServer() : m_gameState_t() {
+NetworkingServer::NetworkingServer(uint32_t tcp_port) : m_gameState_t(), m_tcpPort(tcp_port) {
     m_stateUdpSocketPort = createStateUdpSocket();
     m_inputUdpSocketPort = createInputUdpSocket();
 
@@ -272,7 +272,7 @@ void NetworkingServer::reliableRecvSend() {
     // Create a socket to listen to new connections
     sf::TcpListener listener;
     // Reliable socket
-    listener.listen(GAME_SETTINGS.SERVER_TCP_PORT);
+    listener.listen(m_tcpPort);
 
     // Create a selector
     sf::SocketSelector selector;

--- a/src/server/systems/NetworkingServer.hpp
+++ b/src/server/systems/NetworkingServer.hpp
@@ -23,7 +23,7 @@
 #include "../../common/util/StateDef.hpp"
 
 class NetworkingServer {
-    const uint32_t CMD_DRIFT_THRESHOLD = 200;
+    const uint32_t CMD_DRIFT_THRESHOLD = 7;
 
   public:
     NetworkingServer();

--- a/src/server/systems/NetworkingServer.hpp
+++ b/src/server/systems/NetworkingServer.hpp
@@ -26,7 +26,7 @@ class NetworkingServer {
     const uint32_t CMD_DRIFT_THRESHOLD = 7;
 
   public:
-    NetworkingServer();
+    NetworkingServer(uint32_t tcp_port);
     ~NetworkingServer();
 
     InputDef::PlayerInputs collectClientInputs();
@@ -118,6 +118,8 @@ class NetworkingServer {
     sf::Uint32 m_clientIdCounter = 0;
 
     std::atomic<uint32_t> m_tick_ta{0};
+
+    uint32_t m_tcpPort;
 };
 
 #endif /* NetworkingServer_hpp */

--- a/src/server/systems/ServerGameController.cpp
+++ b/src/server/systems/ServerGameController.cpp
@@ -1,7 +1,7 @@
 #include "ServerGameController.hpp"
 
-ServerGameController::ServerGameController(LevelKey level_key) :
-    GameController(level_key), m_networkingServer(new NetworkingServer()) {
+ServerGameController::ServerGameController(LevelKey level_key, uint32_t tcp_port) :
+    GameController(level_key), m_networkingServer(new NetworkingServer(tcp_port)) {
 }
 
 ServerGameController::~ServerGameController() {

--- a/src/server/systems/ServerGameController.cpp
+++ b/src/server/systems/ServerGameController.cpp
@@ -13,10 +13,10 @@ void ServerGameController::draw() {
     auto broadcast_game_state_rate = m_networkingServer->getBroadcastGameStateRate();
     GameStateObject gso = m_gameObjectController->getGameStateObject();
     auto player_updates = gso.player_updates;
-    m_terminalRenderingController.draw(player_ids_to_updates_rates, player_ids_to_avg_tick_drifts,
-                                       broadcast_game_state_rate, player_updates,
-                                       m_gameStepMetric.getRate(sf::seconds(1)),
-                                       m_gameUpdateMetric.getRate(sf::seconds(1)));
+    m_terminalRenderingController.draw(
+        player_ids_to_updates_rates, player_ids_to_avg_tick_drifts, broadcast_game_state_rate,
+        player_updates, m_gameStepMetric.getRate(sf::seconds(1)),
+        m_gameUpdateMetric.getRate(sf::seconds(1)), m_networkingServer->getTick());
 }
 
 void ServerGameController::start() {

--- a/src/server/systems/ServerGameController.cpp
+++ b/src/server/systems/ServerGameController.cpp
@@ -1,7 +1,7 @@
 #include "ServerGameController.hpp"
 
 ServerGameController::ServerGameController(LevelKey level_key, uint32_t tcp_port) :
-    GameController(level_key), m_networkingServer(new NetworkingServer(tcp_port)) {
+    GameController(level_key), m_terminalRenderingController(tcp_port), m_networkingServer(new NetworkingServer(tcp_port)) {
 }
 
 ServerGameController::~ServerGameController() {

--- a/src/server/systems/ServerGameController.hpp
+++ b/src/server/systems/ServerGameController.hpp
@@ -15,7 +15,7 @@
 
 class ServerGameController : public GameController {
   public:
-    explicit ServerGameController(LevelKey level_key = LevelKey::mine_ring);
+    explicit ServerGameController(LevelKey level_key = LevelKey::mine_ring, uint32_t tcp_port = GAME_SETTINGS.SERVER_TCP_PORT);
     ~ServerGameController();
 
     void start() override;


### PR DESCRIPTION
**Description**

Cmake flags
| Flag  | Second Header |
| ------------- | ------------- |
| UNGROUP_STATIC | Statically link SFML  |
| BUILD_TESTS  | Build tests  |
| ONLY_SERVER  | Only build server  |
| ONLY_CLIENT  | Only build client  |

**Fixes**

Fixes #X
